### PR TITLE
feat: add SPIRE Agent Delegated Identity API support to REST /svid path

### DIFF
--- a/cmd/spire-identity-exchange-server/main.go
+++ b/cmd/spire-identity-exchange-server/main.go
@@ -16,7 +16,9 @@ import (
 	"github.com/spiffe/spire-identity-exchange/internal/config"
 	prommetrics "github.com/spiffe/spire-identity-exchange/internal/metrics/prometheus"
 	"github.com/spiffe/spire-identity-exchange/internal/service"
+	"github.com/spiffe/spire-identity-exchange/internal/service/rest"
 	"github.com/spiffe/spire-identity-exchange/internal/validator"
+	pkggithub "github.com/spiffe/spire-identity-exchange/pkg/validator/github"
 	"github.com/spiffe/spire/cmd/spire-server/util"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -144,7 +146,35 @@ func run() error {
 		return fmt.Errorf("no authentication method enabled")
 	}
 
-	return service.Run(ctx, cfg, spireClient, githubOIDCValidator, k8sSATokenValidator, appMetrics, &logger)
+	// Build the REST plugin registry from operator config. Only registers a
+	// plugin when its auth method is enabled. The REST surface uses these
+	// pkg/validator validators directly because the pkg version exposes
+	// GenerateSelectors (needed for the delegated path); the internal/
+	// validators above remain in use by the gRPC broker path.
+	//
+	// TODO: replay-cache wrap the pkg/validator instances too. The existing
+	// internal/cache.NewReplayCheckingValidator wraps the internal validator
+	// interface; equivalent wrapping for the pkg validator is a follow-up.
+	restPlugins := rest.PluginSet{}
+	if cfg.GitHubOIDC.Enabled && cfg.Server.RestPort != 0 {
+		ghCfg := pkggithub.Config{
+			IssuerURL:           cfg.GitHubOIDC.Issuer,
+			Audiences:           cfg.GitHubOIDC.Audiences,
+			AllowedRepositories: cfg.GitHubOIDC.AllowedRepositories,
+		}
+		ghValidator, err := pkggithub.NewValidator(ghCfg)
+		if err != nil {
+			logger.Error("failed to build pkg github validator for REST path", zap.Error(err))
+			return err
+		}
+		restPlugins["github"] = rest.Plugin{
+			Validator:         ghValidator,
+			SelectorGenerator: ghValidator,
+		}
+		logger.Info("REST plugin registered", zap.String("name", "github"))
+	}
+
+	return service.Run(ctx, cfg, spireClient, githubOIDCValidator, k8sSATokenValidator, service.RESTDeps{Plugins: restPlugins}, appMetrics, &logger)
 }
 
 func parseFlags(logger *zap.Logger) (*config.SpireIdentityExchangeConfig, error) {

--- a/config/config.example-local.json
+++ b/config/config.example-local.json
@@ -12,6 +12,8 @@
   },
   "spire": {
     "unixSocketPath": "/tmp/spire-server/private/api.sock",
+    "agentWorkloadSocketPath": "/tmp/spire-agent/public/api.sock",
+    "agentDelegatedSocketPath": "/tmp/spire-agent/admin/api.sock",
     "trustDomain": "example.org",
     "svidTTL": "1h"
   },

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -12,6 +12,8 @@
   },
   "spire": {
     "unixSocketPath": "/tmp/spire-server/private/api.sock",
+    "agentWorkloadSocketPath": "/tmp/spire-agent/public/api.sock",
+    "agentDelegatedSocketPath": "/tmp/spire-agent/admin/api.sock",
     "trustDomain": "example.org",
     "svidTTL": "5m"
   },

--- a/docs/delegated-api-implementation-plan.md
+++ b/docs/delegated-api-implementation-plan.md
@@ -1,0 +1,589 @@
+# Delegated Identity API — Implementation Plan
+
+This document plans the work to add SPIRE Agent **Delegated Identity API** support to `spire-identity-exchange`, picking up from where [PR #24](https://github.com/spiffe/spire-identity-exchange/pull/24) ("Initial rest api work") leaves off. It is the follow-on to [spire-agent-integration-plan.md](spire-agent-integration-plan.md) (Piece A / Piece B), now grounded in the concrete code path the PR introduces.
+
+## Where things stand
+
+After PR #20 (test framework) and PR #24 (REST scaffolding):
+
+- A SIX agent topology exists in the integration test (Main + SIX, node-aliased to `spiffe://<td>/spire-identity-exchange`).
+- The REST surface exists on `restPort` (8444 in test): `GET /api/v1/trustbundle/x509` works; `POST /api/v1/svid/{plugin}/x509` is a stub that returns `"Hello: <plugin> <selectors-json>"`.
+- The exchange opens a Workload API stream to **Main's** public socket to keep the trust bundle warm in process memory (`trustBundleCache` + `OnX509ContextUpdate`).
+- The gRPC `MintCertificate` path still calls **SPIRE Server's** `MintX509SVID` / `MintJWTSVID` directly — the broker model.
+- **The delegated path is not wired:** the exchange does not yet open a connection to SIX's admin socket, the relevant manifests have bugs that keep entries from reaching SIX's cache, and the REST handler does not issue real SVIDs.
+
+The work below plans five phases (plus a Phase 0 decision-locking step) that take the codebase from "delegated path is exploratory" to "delegated path works end-to-end in CI."
+
+---
+
+## How it works end-to-end (target state)
+
+Once all phases land, a `POST /api/v1/svid/github/x509` call flows through the system like this:
+
+```
+   ┌──────────┐                ┌──────────────────┐         ┌────────────┐         ┌──────────────┐
+   │  caller  │                │  exchange (REST) │         │ SIX agent  │         │ SPIRE Server │
+   │ (GH job) │                │     :8444        │         │ admin UDS  │         │  (cluster)   │
+   └────┬─────┘                └────────┬─────────┘         └──────┬─────┘         └──────┬───────┘
+        │                               │                          │                      │
+        │  ① POST /api/v1/svid/         │                          │                      │
+        │    github/x509                │                          │                      │
+        │    Authorization: Bearer JWT  │                          │                      │
+        │──────────────────────────────▶│                          │                      │
+        │                               │                          │                      │
+        │            ② validate JWT (issuer=GitHub,                │                      │
+        │               audience=spire-identity-exchange,          │                      │
+        │               replay-cache, JWKS-cache)                  │                      │
+        │                               │                          │                      │
+        │            ③ pkg/validator/github/selectors.go:           │                      │
+        │               claims → []selector e.g.                   │                      │
+        │               github_actions:workflow_ref:repo:foo/bar   │                      │
+        │                               │                          │                      │
+        │                               │  ④ SubscribeToX509SVIDs( │                      │
+        │                               │     selectors=[…])       │                      │
+        │                               │  over UDS, no TLS        │                      │
+        │                               │─────────────────────────▶│                      │
+        │                               │                          │                      │
+        │                               │                ⑤ peercred → PID                │
+        │                               │                   workload-attest (systemd)    │
+        │                               │                   → caller SPIFFE ID            │
+        │                               │                   ✓ in authorized_delegates    │
+        │                               │                          │                      │
+        │                               │                ⑥ scan SIX's local cache        │
+        │                               │                   (pre-populated via alias      │
+        │                               │                    inheritance from Server)    │
+        │                               │                   find entry whose selectors    │
+        │                               │                   ⊆ requested                  │
+        │                               │                          │                      │
+        │                               │                          │   (no Server call    │
+        │                               │                          │    in hot path)      │
+        │                               │                          │                      │
+        │                               │  ⑦ stream resp:          │                      │
+        │                               │     X509SVID {           │                      │
+        │                               │       CertChain, Key,    │                      │
+        │                               │       Bundle, ExpiresAt} │                      │
+        │                               │◀─────────────────────────│                      │
+        │                               │                          │                      │
+        │                               │  ⑧ encode to JSON        │                      │
+        │                               │     {spiffeId, cert,     │                      │
+        │                               │      key, bundle,        │                      │
+        │                               │      expiresAt}          │                      │
+        │                               │                          │                      │
+        │  ⑨ 200 OK + JSON              │                          │                      │
+        │◀──────────────────────────────│                          │                      │
+        │                               │                          │                      │
+```
+
+### Step-by-step
+
+1. **Caller hits REST** with the GitHub OIDC JWT in `Authorization: Bearer …`.
+2. **Token validated** using the validator built at startup — JWKS cached, replay cache enforced, audience/issuer checked.
+3. **Claims → selectors** via the existing `pkg/validator/<plugin>/selectors.go` (`GenerateSelectors`).
+4. **Delegated call to SIX**: open gRPC over UDS, call `SubscribeToX509SVIDs(selectors)`. No TLS, no client cert — UDS + filesystem perms are the security boundary.
+5. **SIX attests the caller** via kernel peercred + workload attestor → resolves the exchange's SPIFFE ID → checks `authorized_delegates`.
+6. **SIX scans its local cache** (populated via node-alias inheritance during attestation) for an entry whose selectors are a subset of the requested set.
+7. **SVID returned over the stream**: first message contains cert chain, private key, trust bundle, expiry. Exchange takes it and closes the stream.
+8. **JSON encode** the SVID into the REST response shape.
+9. **200 OK** with `{spiffeId, cert, key, bundle, expiresAt}`.
+
+### What is "delegated" here
+
+Two trust transfers happen:
+
+- **Caller → exchange**: by JWT (GitHub OIDC, validated).
+- **Exchange → SIX**: by process identity (UDS peercred + SIX's local attestation + `authorized_delegates` allow-list).
+
+SIX doesn't need to know what kind of token the caller presented or what validation the exchange did. It trusts the exchange because the exchange's SPIFFE ID is on its allow-list, and serves whatever entry matches within its alias-rooted cache. The hot path is entirely local — no SPIRE Server call, no GitHub JWKS fetch (the JWKS is cached). The Server only participates ahead of time, populating SIX's cache via entry distribution after attestation. That's what makes this design fast and HA-friendly.
+
+### Minimum implementation surface
+
+| Step | Status | New code? |
+|---|---|---|
+| 1 | Route already exists in [PR #24](https://github.com/spiffe/spire-identity-exchange/pull/24) | No |
+| 2 | Validators already built in [main.go:104-140](../cmd/spire-identity-exchange-server/main.go#L104-L140) — needs to be *reused* by the REST handler instead of constructed per request | No (reuse) |
+| 3 | `pkg/validator/github/selectors.go` already in tree | No |
+| **4** | **Delegated client wrapper — new** | **Yes** (~100 lines in `internal/spireagent/delegated/client.go`) |
+| 5, 6 | Runs entirely inside the SIX agent process | No |
+| **7** | **Stream-read + parse — new** (same file as step 4) | **Yes** (~30 lines) |
+| **8** | **Replace the stub `Write("Hello: ...")` with real JSON encoding** in `handleGetX509SVID` | **Yes** (~40 lines, also fixes the WriteHeader/per-request-validator/Content-Type bugs from PR #24) |
+| 9 | Falls out of step 8 | No |
+
+Plus the surrounding plumbing: new `spire.agentDelegatedSocketPath` config field (~10 lines), main.go wiring to construct the client (~10 lines), and the **Phase 1 manifest fixes** (YAML only, ~5 line changes across 3 files).
+
+So the Go code is roughly **150–200 lines new** + the manifest fixes. The `SVIDIssuer` interface (Phase 3 below) is a nice abstraction for keeping the broker and delegated paths separable but is **optional** if the goal is "make the REST endpoint work" without refactoring the existing gRPC path.
+
+---
+
+## Phase 0 — Lock in design decisions (before any code)
+
+These choices affect the abstraction shape, so resolve them first and record the answers in the PR descriptions.
+
+| Decision | Options | Status |
+|---|---|---|
+| CSR support on the delegated path | (a) Drop CSR — agent generates the key. (b) Accept caller CSR | **CONFIRMED — drop.** kfox1111 stated "For now, no csr" on PR #24. The Delegated Identity API does not take a CSR; the agent generates the key. If client-CSR is required, it stays on the broker path (and is removed when the broker path is retired). |
+| REST response shape for issued SVID | (a) PEM bundle (chain + key concatenated). (b) JSON `{ "cert": "pem…", "key": "pem…", "bundle": "pem…", "spiffeId": "…", "expiresAt": … }` | **Recommended: JSON.** Easier to extend with TTL metadata and lifecycle hints. PEM-only on `/trustbundle/x509` stays as is — single thing to return. Implied by the no-CSR decision: the response body must carry the key. |
+| Per-call TTL | (a) Honor a `ttl` field on the request. (b) Use entry TTL only | **Recommended: entry TTL only.** Delegated subscribe doesn't take a per-call TTL; the entry's TTL applies. Document this clearly so operators know to set TTL on the registration entries, not in client requests. |
+| JWT alongside X509 | (a) Same endpoint with content negotiation. (b) Separate endpoint | **Recommended: separate endpoint.** `POST /api/v1/svid/{plugin}/jwt` mirroring `/x509`. Audience comes from request body. Avoids overloading one path with two response shapes. |
+| Validator reuse | (a) Per-request construct (PR #24 stub does this). (b) Reuse the `main.go`-built validator | **Recommended: reuse.** Pass the configured validators (with replay cache + JWKS cache) into the REST handlers. The per-request construction in PR #24's stub must go before more code piles on top. Also called out by kfox1111. |
+| Selectors-from-claims surface | Currently `validator.GenerateSelectors(claims)` is github-specific. | **Recommended: promote `GenerateSelectors` to the `TokenValidator` interface** so the same handler code works for K8s SA and any future plugin. |
+| Broker path future | Keep indefinitely / deprecate / remove | **Pick a timeline.** Coexistence is fine short-term; long-term, the differing TTL/CSR semantics will confuse operators. |
+
+Items still marked "Recommended" need a quick confirm from the PR author before starting Phase 1; the CSR decision is already locked.
+
+---
+
+## Phase 1 — Fix the manifests so SIX is functional (BLOCKER)
+
+Without these fixes, none of the later phases can be tested end-to-end. The bugs are described in detail in the PR reviews; the summary:
+
+### Files to fix
+
+- **`tests/integration/github/manifests/node1-six-nodealias.yaml`**
+
+  ```yaml
+  spec:
+    parentID: spiffe://${SPIFFE_TRUST_DOMAIN}/spire/server   # was /spire
+    spiffeID: spiffe://${SPIFFE_TRUST_DOMAIN}/spire-identity-exchange
+    selectors:
+      - spiffe_id:spiffe://${SPIFFE_TRUST_DOMAIN}/spire/agent/x509pop/spire-identity-exchange/node1
+  ```
+
+  Reason: SPIRE only classifies an entry as a node alias when `ParentId.Path == "/spire/server"` (see [spire/pkg/server/cache/entrycache/fullcache.go:125](../../spire/pkg/server/cache/entrycache/fullcache.go#L125)). With `/spire`, the entry is silently inert and the alias never functions.
+
+- **`tests/integration/github/manifests/six-spire-identity-exchange.yaml`** (introduced in PR #24)
+
+  ```yaml
+  metadata:
+    name: six-spire-identity-exchange       # was node1-spire-identity-exchange (collides with another file!)
+  spec:
+    parentID: spiffe://${SPIFFE_TRUST_DOMAIN}/spire-identity-exchange   # was the x509pop node prefix
+    spiffeID: spiffe://${SPIFFE_TRUST_DOMAIN}/spire-identity-exchange
+    selectors:
+      - systemd:id:spire-identity-exchange@main.service
+  ```
+
+  Two issues: the `metadata.name` collides with the existing `node1-spire-identity-exchange.yaml` (controller-manager applies last-wins, silently dropping one), and the `parentID` doesn't match either the alias or SIX's full node ID (`/node1` suffix missing).
+
+- **`tests/integration/github/manifests/six-github-job.yaml`**
+
+  ```yaml
+  spec:
+    parentID: spiffe://${SPIFFE_TRUST_DOMAIN}/spire-identity-exchange   # was the x509pop node prefix
+    spiffeID: spiffe://${SPIFFE_TRUST_DOMAIN}/github/test
+    selectors:
+      - github_actions:workflow_ref:repo:spiffe/spire-identity-exchange
+      - github_actions:workflow_ref:path:.github/workflows/test.yaml
+  ```
+
+### Test addition
+
+Add an assertion in `tests/integration/github/run-tests.sh` that SIX has the expected entries:
+
+```bash
+# Verify SIX has alias-parented entries in its cache
+sudo spire-agent api fetch -socketPath /var/run/spire/agent/sockets/six/public/api.sock 2>&1 | \
+  grep -q "spiffe://example.org/spire-identity-exchange" || {
+    echo "SIX is not seeing alias-parented entries — check manifests"
+    exit 1
+  }
+```
+
+### Scope
+
+Pure YAML + one shell assertion. Small PR, fast review. Can land into PR #20 or standalone after #20 merges.
+
+---
+
+## Phase 2 — Delegated Identity client wrapper + config
+
+### Config change
+
+In [internal/config/config.go](../internal/config/config.go), extend `SPIREConfig`:
+
+```go
+type SPIREConfig struct {
+    UnixSocketPath           string   `json:"unixSocketPath"`            // existing — server private API
+    AgentWorkloadSocketPath  string   `json:"agentWorkloadSocketPath"`   // PR #24 — Main agent WLA
+    AgentDelegatedSocketPath string   `json:"agentDelegatedSocketPath"`  // NEW — SIX admin socket
+    TrustDomain              string   `json:"trustDomain"`
+    SVIDTTL                  Duration `json:"svidTTL"`
+}
+```
+
+Validation: required when the REST SVID endpoint is enabled. Suggested check (alongside the existing `RestPort` / `AgentWorkloadSocketPath` pairing):
+
+```go
+if c.Server.RestPort != 0 && c.SPIRE.AgentDelegatedSocketPath == "" {
+    errs = append(errs, errors.New("spire.agentDelegatedSocketPath is required when server.restPort is enabled"))
+}
+```
+
+Update `config/config.example.json` and `tests/integration/github/default.json` with realistic values:
+
+```json
+"agentDelegatedSocketPath": "/var/run/spire/agent/sockets/six/admin/api.sock"
+```
+
+### New package: `internal/spireagent/delegated/`
+
+```go
+package delegated
+
+type Client struct {
+    conn *grpc.ClientConn
+    api  delegatedidentityv1.DelegatedIdentityClient
+}
+
+type X509SVID struct {
+    SpiffeID   string
+    CertChain  []*x509.Certificate
+    PrivateKey crypto.PrivateKey
+    ExpiresAt  time.Time
+}
+
+type JWTSVID struct {
+    SpiffeID  string
+    Token     string
+    ExpiresAt time.Time
+}
+
+func NewClient(ctx context.Context, socketPath string) (*Client, error)
+func (c *Client) FetchX509SVID(ctx context.Context, selectors []*types.Selector) (*X509SVID, error)
+func (c *Client) FetchJWTSVID(ctx context.Context, selectors []*types.Selector, audiences []string) (*JWTSVID, error)
+func (c *Client) Close() error
+```
+
+Implementation notes:
+
+- Open the gRPC connection once at process startup using `grpc.NewClient("unix://"+socketPath, grpc.WithTransportCredentials(insecure.NewCredentials()))`. This is correct for UDS: security comes from filesystem permissions and SIX's peercred attestation, not TLS.
+- `FetchX509SVID` calls `SubscribeToX509SVIDs`, takes the first message off the stream, then cancels the request context to close the subscription. Parse `resp.X509Svids[0]` into the local `X509SVID` struct.
+- `FetchJWTSVID` is unary — straightforward call, no stream handling needed.
+- Long-lived `*grpc.ClientConn`. gRPC's built-in connection management handles transient reconnects.
+- Surface error categories so the REST handler can translate them: `ErrNoMatchingEntry` (no entry in SIX's cache matches the selectors), `ErrPermissionDenied` (exchange not in `authorized_delegates`), `ErrUnavailable` (SIX down / socket missing).
+
+### Wiring in `cmd/spire-identity-exchange-server/main.go`
+
+After the existing SPIRE Server client setup (line 75), construct the delegated client and pass it through to `service.Run`:
+
+```go
+delegatedClient, err := delegated.NewClient(ctx, cfg.SPIRE.AgentDelegatedSocketPath)
+if err != nil { return err }
+defer delegatedClient.Close()
+```
+
+### Scope
+
+Standalone PR. Adds plumbing but doesn't change runtime behavior — the new client is constructed and held but nothing calls it yet. Safe to land independently.
+
+---
+
+## Phase 3 — Introduce `SVIDIssuer` abstraction (refactor PR, no behavior change) — OPTIONAL
+
+> **Status: deferrable.** kfox1111's framing on PR #24 ("add the spire-agent delegated api calls to it to go from the selectors to the svid and return it") implies the delegated client can be wired directly into the REST handler without an intermediate interface. Skip this phase if the goal is to land end-to-end functionality quickly and revisit the abstraction when (or if) the broker path needs to dual-back the delegated impl. Keep it if you want the broker (gRPC) and delegated (REST) handlers to share a common dependency surface for testing.
+
+The existing gRPC `MintCertificate` path and the new REST `POST /api/v1/svid/...` path issue SVIDs via two different backends (broker = SPIRE Server, delegated = SIX agent). An interface makes the split explicit and lets them coexist cleanly.
+
+### New file: `internal/service/issuer.go`
+
+```go
+type SVIDIssuer interface {
+    IssueX509(ctx context.Context, selectors []*types.Selector) (*delegated.X509SVID, error)
+    IssueJWT(ctx context.Context, selectors []*types.Selector, audiences []string) (*delegated.JWTSVID, error)
+}
+```
+
+(Or define issuer-specific result types in `internal/service` and keep `delegated.Client` types internal to the delegated package — exact placement is a style call.)
+
+### Two implementations
+
+- **`serverSVIDIssuer`** — wraps the existing `spireClient.NewSVIDClient()`. Used by the gRPC `MintCertificate` handler. Adapts today's calls (which take CSRs and per-call TTLs) into the selector-based interface. *Note:* server-backed issuance does not actually consume selectors — they're ignored. This is a semantic mismatch worth flagging if both paths are kept long-term.
+
+- **`delegatedSVIDIssuer`** — wraps the Phase 2 `delegated.Client`. Used by the new REST handler.
+
+### Refactor scope
+
+- Add `issuer SVIDIssuer` to `SpireIdentityExchangeServer` in [internal/service/server.go](../internal/service/server.go).
+- Update the gRPC `MintCertificate` handlers in [internal/service/mintcertificate.go](../internal/service/mintcertificate.go) to call `h.issuer.IssueX509(...)` / `IssueJWT(...)` instead of `h.spireClient.NewSVIDClient().MintX509SVID(...)`. For the broker path this is a behavior-preserving wrapper.
+- Pass the right issuer in from `main.go` based on which path is being constructed.
+
+### Scope
+
+Pure refactor — gRPC tests continue to pass with `serverSVIDIssuer`. No integration test changes required. Easy review.
+
+---
+
+## Phase 4 — Complete the REST `POST /api/v1/svid/{plugin}/x509` handler
+
+This is the behavior-change PR — where the delegated path actually starts issuing SVIDs end-to-end.
+
+### 4a. Restructure: move REST handlers out of `runner.go`
+
+`runner.go` is meant to be **server lifecycle** code (`Run`, listener setup, graceful shutdown). PR #24 dropped two REST handler bodies (`handleTrustBundleX509`, `handleGetX509SVID`) plus the `trustBundleCache` type into the same file. As the REST surface grows (X509, JWT, future endpoints), `runner.go` becomes a grab-bag.
+
+Suggested layout:
+
+```
+internal/service/
+├── runner.go              # lifecycle: Run, listeners, shutdown — stays small
+├── rest/
+│   ├── handlers.go        # handleGetX509SVID, handleGetJWTSVID
+│   ├── trustbundle.go     # handleTrustBundleX509 + trustBundleCache
+│   └── plugins.go         # plugin registry (see 4b)
+```
+
+`runner.go` reduces to: construct the dependencies (validators, issuer, trust-bundle cache, plugin registry), build the mux, mount the handlers, hand the mux to the HTTPS listener.
+
+### 4b. Plugin registry: name → validator
+
+The URL `POST /api/v1/svid/{plugin}/x509` has a path parameter that PR #24's stub just echoes. The real dispatch needs a registry built once at startup:
+
+```go
+// internal/service/rest/plugins.go
+type PluginSet map[string]validator.TokenValidator
+
+func (p PluginSet) Get(name string) (validator.TokenValidator, bool) {
+    v, ok := p[name]
+    return v, ok
+}
+```
+
+Wired up in `main.go`:
+
+```go
+plugins := rest.PluginSet{}
+if githubOIDCValidator != nil { plugins["github"] = githubOIDCValidator }
+if k8sSATokenValidator != nil { plugins["k8s"]    = k8sSATokenValidator }
+```
+
+The handler does:
+
+```go
+v, ok := plugins.Get(r.PathValue("plugin"))
+if !ok {
+    http.Error(w, "unknown plugin", http.StatusBadRequest)
+    return
+}
+claims, err := v.Validate(r.Context(), token)
+// …
+selectors := v.GenerateSelectors(claims)
+```
+
+Two consequences worth being explicit about:
+
+- **Validators come from `main.go`, not the handler.** PR #24 constructs `github.NewValidator(github.Config{AllowedRepositories: ["spiffe/spire-identity-exchange"], Audiences: ["spire-identity-exchange"]})` per request with hardcoded values. That goes away — operators configure the validator once via JSON, and the handler reuses the validator that's already wrapped with the replay cache + JWKS cache.
+- **`GenerateSelectors` needs to be on the `TokenValidator` interface**, not just the github concrete type, so the dispatch is plugin-agnostic. Today `pkg/validator/github` has it; promote the method to `pkg/validator/interface.go`. Each plugin implements its own selector-generation logic.
+
+### 4c. Handler rewrite
+
+### Handler rewrite
+
+Replace the stub in [internal/service/runner.go](../internal/service/runner.go) with the real flow. Sketch:
+
+```go
+func handleGetX509SVID(
+    issuer SVIDIssuer,
+    validators map[string]validator.TokenValidator,   // keyed by plugin path-param: "github" / "k8s"
+    logger *zap.Logger,
+) http.HandlerFunc {
+    return func(w http.ResponseWriter, r *http.Request) {
+        plugin := r.PathValue("plugin")
+        v, ok := validators[plugin]
+        if !ok {
+            http.Error(w, "unknown plugin", http.StatusBadRequest)
+            return
+        }
+
+        token, err := extractBearerToken(r)
+        if err != nil {
+            http.Error(w, err.Error(), http.StatusUnauthorized)
+            return
+        }
+
+        claims, err := v.Validate(r.Context(), token)
+        if err != nil {
+            logger.Info("token validation failed", zap.Error(err))
+            http.Error(w, "invalid token", http.StatusUnauthorized)
+            return
+        }
+
+        selectors := v.GenerateSelectors(claims)
+        if len(selectors) == 0 {
+            http.Error(w, "no selectors derivable from claims", http.StatusBadRequest)
+            return
+        }
+
+        svid, err := issuer.IssueX509(r.Context(), selectors)
+        switch {
+        case errors.Is(err, delegated.ErrNoMatchingEntry):
+            http.Error(w, "no registration entry matches", http.StatusNotFound)
+            return
+        case errors.Is(err, delegated.ErrUnavailable):
+            http.Error(w, "issuance backend unavailable", http.StatusServiceUnavailable)
+            return
+        case err != nil:
+            logger.Error("svid issuance failed", zap.Error(err))
+            http.Error(w, "issuance failed", http.StatusInternalServerError)
+            return
+        }
+
+        resp := struct {
+            SpiffeID  string `json:"spiffeId"`
+            Cert      string `json:"cert"`
+            Key       string `json:"key"`
+            Bundle    string `json:"bundle"`
+            ExpiresAt int64  `json:"expiresAt"`
+        }{
+            SpiffeID:  svid.SpiffeID,
+            Cert:      encodeChainPEM(svid.CertChain),
+            Key:       encodePKCS8PEM(svid.PrivateKey),
+            Bundle:    string(cache.Get()),
+            ExpiresAt: svid.ExpiresAt.Unix(),
+        }
+        w.Header().Set("Content-Type", "application/json")
+        if err := json.NewEncoder(w).Encode(resp); err != nil {
+            logger.Error("response encode failed", zap.Error(err))
+        }
+    }
+}
+```
+
+### Bugs from PR #24 wrapped into this PR
+
+- **`WriteHeader(http.StatusOK)` before validation** — gone. `WriteHeader` only fires on success (implicitly via the first `Write`).
+- **Per-request `github.NewValidator(...)`** — gone. Validators come from `main.go` (with replay cache, JWKS cache, configured allow-list).
+- **Hardcoded `AllowedRepositories: ["spiffe/spire-identity-exchange"]`** — gone. Operator config rules.
+- **`Content-Type: "plain/text"`** — moot, the new response is JSON.
+
+### JWT counterpart
+
+Add `POST /api/v1/svid/{plugin}/jwt` with the same shape:
+
+```go
+type jwtRequest struct {
+    Audiences []string `json:"audiences"`
+}
+```
+
+Validation: at least one audience is required (mirrors the gRPC `mintJWTSVIDFromClaims` check at [mintcertificate.go:274-279](../internal/service/mintcertificate.go#L274-L279)).
+
+### Selector-generation contract
+
+`pkg/validator/github/selectors.go` already exists. Confirm the selectors it produces (e.g., `github_actions:workflow_ref:*`) match the selectors on the alias-parented entries from Phase 1 **exactly**. A debug log in the delegated client that prints the requested selectors when `IssueX509` returns no-match is worth adding — it's the cheapest way to diagnose mismatches in operations.
+
+Add a unit test asserting selectors are only derived after `Validate(...)` returns nil — guards against a future refactor accidentally letting unvalidated claims into selector construction.
+
+---
+
+## Phase 5 — Integration test
+
+Update `tests/integration/github/run-tests.sh` to replace the stub-echo curl call with a real assertion:
+
+```bash
+RESPONSE=$(curl -fsS -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -X POST https://localhost:8444/api/v1/svid/github/x509 \
+  --cacert /etc/spire/identity-exchange/main/certs/server.pem)
+
+echo "$RESPONSE" | jq -e '.spiffeId' > /dev/null || { echo "no spiffeId in response"; exit 1; }
+echo "$RESPONSE" | jq -r '.cert'   > /tmp/svid.pem
+echo "$RESPONSE" | jq -r '.bundle' > /tmp/bundle.pem
+
+# Verify it's a SPIFFE cert
+openssl x509 -in /tmp/svid.pem -text -noout | grep -q "URI:spiffe://" || {
+  echo "issued cert has no SPIFFE URI SAN"; exit 1
+}
+
+# Verify it chains to the trust bundle
+openssl verify -CAfile /tmp/bundle.pem /tmp/svid.pem || exit 1
+
+echo "delegated X509 SVID issuance verified end-to-end"
+```
+
+Mirror the same pattern for the JWT endpoint:
+
+```bash
+RESPONSE=$(curl -fsS -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -X POST https://localhost:8444/api/v1/svid/github/jwt \
+  -H 'Content-Type: application/json' \
+  -d '{"audiences":["foo"]}' \
+  --cacert /etc/spire/identity-exchange/main/certs/server.pem)
+
+TOKEN=$(echo "$RESPONSE" | jq -r '.token')
+[ -n "$TOKEN" ] || { echo "no token in response"; exit 1; }
+# (Optionally verify the JWT signature against the JWT bundle from spire-server bundle show)
+```
+
+The existing X509 `grpcurl` line (the commented-out `MintX509SVID` call from PR #20) can stay commented out, or be re-enabled if the broker path is going to be supported long-term.
+
+---
+
+## Phase 6 — Docs + operator guide
+
+- **README**: add the broker-vs-delegated comparison and the recommended deployment topology (link to the existing topology section).
+- **`config/config.example.json`**: include the new `agentDelegatedSocketPath` and a comment explaining what it points at.
+- **`docs/spire-agent-integration-plan.md`** (the existing plan doc): update Piece B's status to "implemented" with a pointer to this document.
+- **New section in this doc or a separate `docs/delegated-api-operator-guide.md`**: the operator-side prerequisites:
+  - Run a SIX agent with `admin_socket_path` and `authorized_delegates` including the exchange's SPIFFE ID.
+  - Pre-register entries parented under `spiffe://<td>/spire-identity-exchange` with selectors matching `pkg/validator/<plugin>/selectors.go` output.
+  - Document the selector vocabulary per plugin (GitHub OIDC, K8s SA, future).
+
+---
+
+## Suggested PR sequence
+
+### Minimum viable scope (matches kfox1111's PR #24 framing)
+
+| PR | Phase(s) | Scope | Review effort |
+|---|---|---|---|
+| **PR-A** | Phase 1 | Manifest fixes (YAML only + one shell assertion) | Tiny |
+| **PR-B** | Phase 2 | Delegated client wrapper + config field + main.go wiring | Small |
+| **PR-C** | Phase 4 + 5 | Restructure handlers out of `runner.go`, plugin registry, REST handler rewrite, integration test | **Medium** — the real review attention |
+| **PR-D** | Phase 6 | Docs | Tiny |
+
+Three PRs to land the end-to-end delegated path. Phase 3 (`SVIDIssuer` abstraction) is skipped — the delegated client is wired directly into the REST handler.
+
+### Full scope (if SVIDIssuer abstraction is wanted)
+
+| PR | Phase(s) | Scope | Review effort |
+|---|---|---|---|
+| **PR-A** | Phase 1 | Manifest fixes | Tiny |
+| **PR-B** | Phase 2 | Delegated client wrapper + config field + main.go wiring | Small |
+| **PR-C** | Phase 3 | `SVIDIssuer` abstraction (pure refactor, no behavior change) | Small |
+| **PR-D** | Phase 4 + 5 | Restructure handlers out of `runner.go`, plugin registry, REST handler rewrite, integration test | **Medium** |
+| **PR-E** | Phase 6 | Docs | Tiny |
+
+Five PRs; PR-A through PR-C are mechanically simple and review fast. PR-D is the behavior-introducing one.
+
+### Pick which sequence
+
+Default to the minimum-viable scope unless there's a near-term reason to dual-back the broker path (e.g., the broker path is staying long-term and needs to share testing fixtures with the delegated path). Otherwise the abstraction can be introduced later when its motivation actually materializes.
+
+---
+
+## Risks and gotchas
+
+- **Connection lifecycle on the delegated client.** If SIX restarts, the gRPC `ClientConn` auto-reconnects, but the first call after the restart may fail. Decide whether to wrap with a single retry inside the client, or surface the error and rely on the caller (CI / curl client) to retry.
+
+- **SIX agent attestation startup race.** The exchange may come up before SIX has finished attesting and populated its cache. The first delegated calls return "no matching entry." Either bake a startup wait into `run-tests.sh` (same pattern as `wait_for_jwt`), or surface 503 from the handler and document operator-side retry expectations.
+
+- **Selector vocabulary drift.** If the validator emits selectors slightly different from what's registered on entries (e.g., `github_actions:workflow_ref:...` vs `github:workflow_ref:...`), every call returns "no match" with no obvious diagnostic. The debug-log-selectors-on-no-match note in Phase 4 is cheap defense.
+
+- **Broker / delegated coexistence.** While both paths are wired, an operator could end up with two SVIDs for the same identity with different TTLs (broker = client-controlled, delegated = entry-controlled). Pick a deprecation timeline for the broker path before this becomes a support burden.
+
+- **Per-call selector freshness.** The exchange must construct selectors from **validated** claims and pass them as-is. If a future refactor lets unvalidated claims sneak into selector construction, the security model breaks (the exchange could be tricked into asking for selectors that match a more-privileged entry). A unit test asserting "selectors are only derived after `Validate` returns nil" is cheap insurance.
+
+- **`authorized_delegates` is a binary trust grant.** Once the exchange is on SIX's `authorized_delegates`, it can fetch any SVID for any entry in SIX's cache — there is no per-call authorization. The alias-parented entry tree IS the security boundary; nothing structural prevents the exchange from issuing any identity that lives under the alias. Operator discipline around what goes under the alias is essential.
+
+- **No replay cache on the REST path today.** PR #24 constructs a fresh validator per request and skips the `cache.NewReplayCheckingValidator` wrapping that the gRPC path uses. Phase 4 fixes this by reusing the configured validator — but the fix must actually happen, or the REST path remains replay-vulnerable.
+
+---
+
+## Definition of done
+
+The delegated path is "implemented" when:
+
+1. The integration test in CI runs the full chain: real GitHub OIDC token → REST endpoint → exchange validates → derives selectors → calls SIX → SIX returns SVID → REST returns JSON with cert/key/bundle.
+2. The returned cert is a valid SPIFFE-URI-SAN X.509 cert that chains to the trust bundle.
+3. Replay attempts against the REST endpoint are rejected by the shared replay cache.
+4. Error paths return the right status codes (401 for bad token, 404 for no matching entry, 503 for backend down, 500 for internal).
+5. Docs explain to operators how to register entries under the alias and what selectors each validator emits.
+6. The broker path (gRPC `MintCertificate`) continues to work — no regression — until a deprecation decision is made.

--- a/docs/spire-agent-integration-plan.md
+++ b/docs/spire-agent-integration-plan.md
@@ -1,0 +1,191 @@
+# SPIRE Agent Integration Plan
+
+This document describes how to extend `spire-identity-exchange` to talk to a SPIRE Agent instead of (or in addition to) the SPIRE Server directly. There are two independent pieces:
+
+- **Piece A** — Use the Workload API for the exchange's own SVID (server-side TLS on the public listener).
+- **Piece B** — Use the Delegated Identity API for minting/fetching SVIDs returned to callers.
+
+Today the exchange:
+
+- Loads the listener TLS cert from disk (`server.tls.certFile` / `keyFile`), which never rotates — see [internal/service/runner.go](../internal/service/runner.go).
+- Calls SPIRE Server's SVID v1 API (`MintX509SVID` / `MintJWTSVID`) over a private UDS — see [internal/service/mintcertificate.go](../internal/service/mintcertificate.go).
+
+The target deployment (per the architecture diagram) inserts SPIRE Agent(s) between the exchange and the SPIRE Server. See [project_six_agent_topology.md](https://github.com/spiffe/spire-identity-exchange) for the node-alias HA topology behind the two-agent split.
+
+---
+
+## Piece A — Workload API for the exchange's own SVID
+
+**Goal:** Replace the static, disk-loaded TLS cert with a SPIFFE Workload API source so the listener SVID rotates automatically and follows whatever the Main agent's attestation produces.
+
+### What changes
+
+| Area | Before | After |
+|---|---|---|
+| Listener cert | `tls.LoadX509KeyPair(certFile, keyFile)` | `tlsconfig.TLSServerConfig(x509Source)` |
+| Rotation | Manual (operator replaces files, restart) | Automatic (agent rotates via workload API) |
+| Config | `server.tls.{certFile,keyFile}` | `spireAgent.workloadAPISocketPath` |
+| Dependency | `crypto/tls` only | `github.com/spiffe/go-spiffe/v2/{workloadapi,spiffetls/tlsconfig}` |
+
+### Config additions
+
+```json
+"spireAgent": {
+  "workloadAPISocketPath": "/var/run/spire/agents/main/public/api.sock"
+}
+```
+
+Add validation that the socket path is set and is an absolute path. The legacy `server.tls.{certFile,keyFile}` block can either be deleted or kept as a dev-only fallback gated by a `mode` flag — recommendation is to **delete** it; the exchange is a SPIFFE workload, so a static disk cert is the wrong shape long-term.
+
+### Code changes (concrete)
+
+1. **[internal/config/config.go](../internal/config/config.go)** — add a `SpireAgentConfig` struct and a `SpireAgent SpireAgentConfig` field on `SpireIdentityExchangeConfig`. Validate `workloadAPISocketPath` is non-empty and absolute. Remove or weaken `TLSConfig` validation.
+
+2. **[internal/service/runner.go](../internal/service/runner.go)** — replace the `tls.LoadX509KeyPair` block (around lines 97-104) with:
+
+   ```go
+   src, err := workloadapi.NewX509Source(ctx,
+       workloadapi.WithClientOptions(
+           workloadapi.WithAddr("unix://"+cfg.SpireAgent.WorkloadAPISocketPath),
+       ),
+   )
+   if err != nil {
+       return fmt.Errorf("failed to create X509 source from workload API: %w", err)
+   }
+   defer src.Close()
+
+   tlsConfig := tlsconfig.TLSServerConfig(src)
+   tlsConfig.MinVersion = tls.VersionTLS13
+   ```
+
+   Both the gRPC server and the HTTP gateway already share `tlsConfig` — no other listener changes needed.
+
+3. **Imports** — `github.com/spiffe/go-spiffe/v2/workloadapi`, `github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig`. Both are already transitively in `go.sum` via `spire-api-sdk`.
+
+4. **Operator docs / example config** — update [config/config.example.json](../config/config.example.json) and [config/config.example-local.json](../config/config.example-local.json).
+
+### Operator prerequisites
+
+- A registration entry must exist on SPIRE Server giving the exchange process its own SPIFFE ID (e.g. `spiffe://<td>/spire-identity-exchange/server`), parented to whichever agent serves the process (Main agent in the two-agent topology), with selectors matching the running process (`unix:uid:…`, `unix:path:…`).
+- The Main agent's public socket must be reachable from the exchange process (same node, filesystem perms).
+
+### Risk / rollback
+
+- **Risk:** misconfigured agent socket → process can't start (no listener cert). Surfaces immediately at startup, not in production traffic. Acceptable.
+- **Rollback:** revert config change. No data migration. The disk-cert code path can be retained behind a config flag during a rollout window if desired, but it adds dead-code-removal debt — prefer a clean swap on a maintenance window.
+
+### Effort
+
+~50–100 lines including config, validation, tests. One PR.
+
+---
+
+## Piece B — Delegated Identity API for minted SVIDs
+
+**Goal:** Replace direct SPIRE Server `MintX509SVID` / `MintJWTSVID` calls with the SPIRE Agent's Delegated Identity API on the SIX agent's admin socket.
+
+### Critical semantic difference (read before designing)
+
+The Delegated Identity API is **not** a "mint with arbitrary SPIFFE ID and CSR" API. The four RPCs (verified against [spire/pkg/agent/api/delegatedidentity/v1/service.go](../../spire/pkg/agent/api/delegatedidentity/v1/service.go)) are:
+
+| RPC | Input | Returns |
+|---|---|---|
+| `SubscribeToX509SVIDs` | `selectors` | Stream of SVIDs for registration entries matching the selectors |
+| `SubscribeToX509Bundles` | — | Stream of trust bundles |
+| `FetchJWTSVIDs` | `audiences`, `selectors` | JWT-SVIDs for matching entries |
+| `SubscribeToJWTBundles` | — | Stream of JWT signing keys |
+
+The agent serves SVIDs **for registration entries that already exist** on SPIRE Server (delivered to the agent via the normal entry-distribution path). The CSR and arbitrary-SPIFFE-ID model from `MintX509SVID` is gone.
+
+This collides with how the exchange works today:
+
+| Today (Server SVID v1) | With Delegated Identity API |
+|---|---|
+| SPIFFE ID derived from claims at request time via Go template | SPIFFE ID is whatever the matched registration entry says |
+| No registration entry required | Entry **must** exist on SPIRE Server, parented under the SIX node alias |
+| Caller controls TTL per-call | Entry's TTL applies (per-call TTL not honored by the agent's delegated subscribe) |
+| Caller supplies CSR; key material is client-side | Agent generates key material; no CSR |
+
+### How this fits the SIX node-alias topology
+
+(See [project_six_agent_topology.md](https://github.com/spiffe/spire-identity-exchange) for the topology explanation.)
+
+- A node-alias entry `spiffe://<td>/spire-identity-exchange` is registered with `parentID = spiffe://<td>/spire/server` and selectors matching the SIX agent's node attestation.
+- All exchange-issuable workload entries are registered with `parentID = spiffe://<td>/spire-identity-exchange`. Every SIX agent in the cluster receives the full entry set after attestation.
+- At request time the exchange maps validated token claims → selectors → `SubscribeToX509SVIDs(selectors)`. The SIX agent finds the matching entry in its local cache and returns the SVID.
+
+### Two sub-models — pick one
+
+**Model 1: Operator pre-registers entries.** All `github:repo:org/repo` and `k8s:sa:ns/sa` entries are created out-of-band (Terraform / a controller / `spire-server entry create`). The exchange is purely a fetcher — no SPIRE Server access needed in the request path. Cleanest, but every new repo/SA requires an entry-management workflow outside the exchange.
+
+**Model 2: Exchange manages entries.** On the first call for a new claim shape, the exchange creates the entry via SPIRE Server's Entry API, then fetches via Delegated. Preserves "any token → any identity" semantics, but the exchange still needs Entry API access to SPIRE Server (not just the agent sockets), and requires a creation-on-demand path with careful idempotency, rate limiting, and cleanup. The diagram's "exchange only talks to agents" becomes "exchange talks to two agents + Entry API on server."
+
+**Recommendation:** Model 1. It matches the SIX-alias topology better, keeps the exchange stateless, and pushes the "who is allowed an identity" decision into entry management (a deliberate, auditable surface) rather than into the exchange's claims→template code.
+
+### What disappears under Model 1
+
+- `spiffeIdTemplate` config on GitHub OIDC and K8s SA blocks — no longer the source of truth for the SPIFFE ID.
+- The CSR validation path in `mintX509SVIDFromClaims` — the agent generates the key.
+- The server-side-keygen path (`mintX509SVIDServerKeyGen`) — the agent already does this.
+- Per-call `Ttl` from the request — the entry's TTL applies.
+
+That's substantial behavior loss. **The exchange's public API may need to change** (e.g. drop the CSR field, drop the per-call TTL field, or document them as ignored). This is the biggest decision in Piece B.
+
+### What needs to be added
+
+1. **`SVIDIssuer` interface in `internal/service`** — abstract the two backends.
+
+   ```go
+   type SVIDIssuer interface {
+       IssueX509(ctx context.Context, selectors []*types.Selector) (*X509SVID, error)
+       IssueJWT(ctx context.Context, selectors []*types.Selector, audiences []string) (*JWTSVID, error)
+   }
+   ```
+
+   Implementations: `serverSVIDIssuer` (current behavior, kept for transition / non-SIX deployments) and `delegatedSVIDIssuer` (new).
+
+2. **`selectorsFromClaims` per auth method** — the contract between the exchange and entry creators.
+
+   - GitHub OIDC: `repository` claim → selector `github:repo:<repo>`. Possibly `repository_owner`, `workflow_ref`, `job_workflow_ref`, `event_name` as additional selectors so an entry can scope to a specific workflow.
+   - K8s SA: `sub` claim → selector(s) like `k8s:sa:<namespace>:<sa-name>`. The selector vocabulary needs design; see the [SPIFFE ID Template Guide](spiffe-id-template-guide.md) for what claims are available.
+
+3. **Delegated Identity client wrapper** — a small client on `delegatedidentityv1.DelegatedIdentityClient` that does a single fetch (the API is streaming, but the exchange wants one-shot semantics; take the first message from the stream then close).
+
+4. **Config additions:**
+
+   ```json
+   "spireAgent": {
+     "workloadAPISocketPath": "/var/run/spire/agents/main/public/api.sock",
+     "delegatedSocketPath":   "/var/run/spire/agents/six/admin/api.sock"
+   }
+   ```
+
+5. **Caller authorization on the SIX agent** — the SIX agent's `authorized_delegates` must include the exchange's own SPIFFE ID (e.g. `spiffe://<td>/spire-identity-exchange/server`). This requires an entry for the exchange process parented under the SIX alias with `unix:uid:` / `unix:path:` selectors. Document this as an operator prerequisite.
+
+### Code changes (concrete)
+
+- **[internal/service/mintcertificate.go](../internal/service/mintcertificate.go)** — replace direct calls at `mintcertificate.go:249`, `:293`, `:363` with `h.issuer.IssueX509(…)` / `IssueJWT(…)`. Remove/guard CSR validation in `mintX509SVIDFromClaims`. Decide fate of `mintX509SVIDServerKeyGen`.
+- **`internal/service/issuer_server.go`** (new) — wraps current `spireClient.NewSVIDClient()` behavior behind `SVIDIssuer`.
+- **`internal/service/issuer_delegated.go`** (new) — wraps `delegatedidentityv1.NewDelegatedIdentityClient` behind `SVIDIssuer`.
+- **`internal/service/selectors.go`** (new) — `selectorsFromClaims` per auth method.
+- **[internal/service/server.go](../internal/service/server.go)** — `NewGRPCHandler` takes a `SVIDIssuer` instead of a `server_util.ServerClient`; the choice is made in `main.go` based on config.
+- **[cmd/spire-identity-exchange-server/main.go](../cmd/spire-identity-exchange-server/main.go)** — pick the issuer based on whether `spireAgent.delegatedSocketPath` is set.
+
+### Operator prerequisites
+
+- The node-alias entry `spiffe://<td>/spire-identity-exchange` must exist.
+- The SIX agent must be configured with `admin_socket_path` and `authorized_delegates = ["spiffe://<td>/spire-identity-exchange/server"]`.
+- Every identity the exchange is expected to issue must have a registration entry parented under the SIX alias, with selectors matching `selectorsFromClaims`'s output for that auth method.
+
+### Effort
+
+Several PRs. The interface swap and one issuer impl is ~200 lines plus tests. The selectors design and the public-API decision (CSR/TTL fields) are the gating discussions, not the code.
+
+---
+
+## Recommended sequencing
+
+1. **Piece A first.** Independent, low-risk, immediate win (rotated listener SVID), and forces the operator-side prerequisite of running an agent next to the exchange — which Piece B builds on.
+2. **Decide Piece B sub-model.** Model 1 (operator-pre-registers) recommended. Document the selectors contract per auth method.
+3. **Piece B in two PRs:** (a) introduce the `SVIDIssuer` interface and refactor the existing flow behind it (no behavior change), (b) add the delegated implementation and config wiring.
+4. **Public API decision.** Decide CSR field / per-call TTL field fate. Communicate to existing callers before flipping the issuer.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,8 +59,16 @@ type SPIREConfig struct {
 	// Unix domain socket path for SPIRE Server API
 	UnixSocketPath string `json:"unixSocketPath"`
 
-	// Unix domain socket path for SPIRE Agent Workload API
+	// Unix domain socket path for SPIRE Agent Workload API.
+	// Used by the REST trust-bundle endpoint to stream bundle updates.
 	AgentWorkloadSocketPath string `json:"agentWorkloadSocketPath"`
+
+	// Unix domain socket path for SPIRE Agent Delegated Identity API.
+	// When set, the REST /svid/{plugin}/x509 endpoint issues SVIDs by fetching
+	// them through this socket rather than calling SPIRE Server directly. The
+	// agent listening on this socket must include this exchange's SPIFFE ID in
+	// its authorized_delegates configuration.
+	AgentDelegatedSocketPath string `json:"agentDelegatedSocketPath"`
 
 	// Trust domain
 	TrustDomain string `json:"trustDomain"`
@@ -294,6 +302,9 @@ func (c *SpireIdentityExchangeConfig) Validate() error {
 
 	if c.Server.RestPort != 0 && c.SPIRE.AgentWorkloadSocketPath == "" {
 		errs = append(errs, errors.New("spire.agentWorkloadSocketPath is required when server.restPort is enabled"))
+	}
+	if c.Server.RestPort != 0 && c.SPIRE.AgentDelegatedSocketPath == "" {
+		errs = append(errs, errors.New("spire.agentDelegatedSocketPath is required when server.restPort is enabled"))
 	}
 
 	if len(errs) > 0 {

--- a/internal/service/rest/handlers.go
+++ b/internal/service/rest/handlers.go
@@ -1,0 +1,185 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+
+	"github.com/spiffe/spire-identity-exchange/internal/spireagent/delegated"
+	"go.uber.org/zap"
+)
+
+// Deps groups everything the REST handlers need. Keeping it as a struct keeps
+// each HandleFunc factory simple (one arg) and makes future additions cheap.
+type Deps struct {
+	TrustBundle *TrustBundleCache
+	Delegated   DelegatedFetcher
+	Plugins     PluginSet
+	Logger      *zap.Logger
+}
+
+// DelegatedFetcher is the subset of *delegated.Client the handlers depend on.
+// Defined as an interface so tests can inject a fake without standing up a
+// SPIRE agent socket.
+type DelegatedFetcher interface {
+	FetchX509SVID(ctx context.Context, selectors []*types.Selector) (*delegated.X509SVID, error)
+}
+
+// x509SVIDResponse is the JSON body returned by POST /api/v1/svid/{plugin}/x509.
+type x509SVIDResponse struct {
+	SpiffeID  string `json:"spiffeId"`
+	Cert      string `json:"cert"`      // PEM, leaf first
+	Key       string `json:"key"`       // PEM-encoded PKCS#8 private key
+	Bundle    string `json:"bundle"`    // PEM, trust bundle
+	ExpiresAt int64  `json:"expiresAt"` // Unix seconds
+}
+
+// HandleTrustBundleX509 returns the cached trust bundle as a PEM file.
+// The handler is unauthenticated — trust bundles are public by SPIFFE design.
+// Returns 503 during the startup window before the first watcher push lands.
+func HandleTrustBundleX509(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		pemBytes := d.TrustBundle.Get()
+		if len(pemBytes) == 0 {
+			d.Logger.Warn("trust bundle requested but cache is empty or warming up")
+			http.Error(w, "Trust bundle warming up or unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/x-pem-file")
+		_, _ = w.Write(pemBytes)
+	}
+}
+
+// HandleGetX509SVID validates the bearer token, derives selectors via the
+// plugin's SelectorGenerator, fetches an SVID via the delegated client, and
+// returns it as JSON.
+//
+// Error mapping:
+//   - missing/malformed Authorization header → 401
+//   - unknown {plugin} path-param            → 400
+//   - token rejected by validator            → 401
+//   - validator returned no selectors        → 400
+//   - delegated client found no matching entry → 404
+//   - delegated client unavailable           → 503
+//   - any other error                        → 500
+func HandleGetX509SVID(d Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		token, err := extractBearerToken(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusUnauthorized)
+			return
+		}
+
+		pluginName := r.PathValue("plugin")
+		plugin, ok := d.Plugins.Get(pluginName)
+		if !ok {
+			http.Error(w, fmt.Sprintf("unknown plugin: %q", pluginName), http.StatusBadRequest)
+			return
+		}
+
+		claims, err := plugin.Validator.Validate(r.Context(), token)
+		if err != nil {
+			d.Logger.Info("token validation failed", zap.String("plugin", pluginName), zap.Error(err))
+			http.Error(w, "invalid token", http.StatusUnauthorized)
+			return
+		}
+
+		selectors := plugin.SelectorGenerator.GenerateSelectors(claims)
+		if len(selectors) == 0 {
+			http.Error(w, "no selectors derivable from token claims", http.StatusBadRequest)
+			return
+		}
+
+		svid, err := d.Delegated.FetchX509SVID(r.Context(), selectors)
+		switch {
+		case errors.Is(err, delegated.ErrNoMatchingEntry):
+			d.Logger.Info("no entry matched selectors",
+				zap.String("plugin", pluginName),
+				zap.Int("selector_count", len(selectors)),
+				zap.Any("selectors", debugSelectors(selectors)))
+			http.Error(w, "no registration entry matches the validated identity", http.StatusNotFound)
+			return
+		case errors.Is(err, delegated.ErrPermissionDenied):
+			d.Logger.Error("delegated API rejected this exchange — check authorized_delegates", zap.Error(err))
+			http.Error(w, "delegated issuance unavailable", http.StatusServiceUnavailable)
+			return
+		case errors.Is(err, delegated.ErrUnavailable):
+			d.Logger.Error("delegated API unavailable", zap.Error(err))
+			http.Error(w, "delegated issuance unavailable", http.StatusServiceUnavailable)
+			return
+		case err != nil:
+			d.Logger.Error("delegated svid fetch failed", zap.Error(err))
+			http.Error(w, "issuance failed", http.StatusInternalServerError)
+			return
+		}
+
+		resp := x509SVIDResponse{
+			SpiffeID:  svid.SpiffeID,
+			Cert:      encodeCertChainPEM(svid.CertChain),
+			Key:       encodePKCS8KeyPEM(svid.PrivateKey),
+			Bundle:    string(d.TrustBundle.Get()),
+			ExpiresAt: svid.ExpiresAt.Unix(),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(&resp); err != nil {
+			d.Logger.Error("response encode failed", zap.Error(err))
+		}
+	}
+}
+
+// extractBearerToken reads and validates the Authorization header.
+func extractBearerToken(r *http.Request) (string, error) {
+	header := r.Header.Get("Authorization")
+	if header == "" {
+		return "", errors.New("missing Authorization header")
+	}
+	const prefix = "bearer "
+	if len(header) < len(prefix) || !strings.EqualFold(header[:len(prefix)], prefix) {
+		return "", errors.New("invalid Authorization header format")
+	}
+	token := strings.TrimSpace(header[len(prefix):])
+	if token == "" {
+		return "", errors.New("empty bearer token")
+	}
+	return token, nil
+}
+
+// encodeCertChainPEM concatenates the DER-encoded chain into a multi-block
+// PEM bundle, leaf first. Matches what `cat svid.pem chain.pem` would produce
+// from a SPIRE-Agent-served SVID.
+func encodeCertChainPEM(chain [][]byte) string {
+	var out []byte
+	for _, der := range chain {
+		out = append(out, pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: der,
+		})...)
+	}
+	return string(out)
+}
+
+// encodePKCS8KeyPEM wraps the PKCS#8 DER-encoded private key the agent
+// returns into a PEM block. We do not type-assert on the key algorithm — the
+// agent owns key generation and PKCS#8 covers ECDSA, RSA, and Ed25519.
+func encodePKCS8KeyPEM(der []byte) string {
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: der,
+	}))
+}
+
+// debugSelectors flattens selectors into "type:value" strings for log output.
+// Helps diagnose selector-mismatch issues without dumping raw proto.
+func debugSelectors(selectors []*types.Selector) []string {
+	out := make([]string, 0, len(selectors))
+	for _, s := range selectors {
+		out = append(out, s.Type+":"+s.Value)
+	}
+	return out
+}

--- a/internal/service/rest/plugins.go
+++ b/internal/service/rest/plugins.go
@@ -1,0 +1,30 @@
+package rest
+
+import (
+	"github.com/spiffe/spire-identity-exchange/pkg/validator"
+)
+
+// Plugin pairs a token validator with a selector generator. Both are required
+// for the /svid/{plugin}/x509 path to issue an SVID: Validate produces claims,
+// GenerateSelectors turns those claims into SPIRE selectors.
+//
+// Both pkg/validator/github.Validator and (future) k8s validators implement
+// both pkg/validator.TokenValidator and pkg/validator.SelectorGenerator, so a
+// single concrete validator is typically stored in both fields.
+type Plugin struct {
+	Validator         validator.TokenValidator
+	SelectorGenerator validator.SelectorGenerator
+}
+
+// PluginSet maps a URL path-param name (e.g. "github", "k8s") to its
+// configured Plugin. Population happens once at startup in main.go; lookup is
+// a single map read per request.
+type PluginSet map[string]Plugin
+
+// Get returns the plugin registered under name. The second return value is
+// false if no plugin is registered under that name, in which case the handler
+// should respond with 400.
+func (p PluginSet) Get(name string) (Plugin, bool) {
+	v, ok := p[name]
+	return v, ok
+}

--- a/internal/service/rest/server.go
+++ b/internal/service/rest/server.go
@@ -1,0 +1,13 @@
+package rest
+
+import "net/http"
+
+// NewMux builds a *http.ServeMux with the REST routes wired up using the
+// supplied dependencies. Keeps route registration in one place so the
+// lifecycle code in runner.go can simply build it and pass it to the listener.
+func NewMux(d Deps) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/trustbundle/x509", HandleTrustBundleX509(d))
+	mux.HandleFunc("POST /api/v1/svid/{plugin}/x509", HandleGetX509SVID(d))
+	return mux
+}

--- a/internal/service/rest/trustbundle.go
+++ b/internal/service/rest/trustbundle.go
@@ -1,0 +1,78 @@
+// Package rest implements the HTTP/REST surface of spire-identity-exchange.
+// It is kept separate from the gRPC handler package so that runner.go can stay
+// focused on server lifecycle.
+package rest
+
+import (
+	"encoding/pem"
+	"sync"
+
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+	"go.uber.org/zap"
+)
+
+// TrustBundleCache is a goroutine-safe in-memory mirror of the local trust
+// bundle delivered by the SPIRE Agent's Workload API. It implements
+// workloadapi.X509ContextWatcher so it can be passed directly into
+// workloadapi.Client.WatchX509Context.
+//
+// Encoding is done eagerly on each update so the HTTP hot path is a single
+// RLock + slice copy. SVID-only updates from the agent (no bundle change) do
+// a wasteful re-encode of the same PEM but keep the cache code branch-free.
+type TrustBundleCache struct {
+	mu       sync.RWMutex
+	pemBytes []byte
+	logger   *zap.Logger
+}
+
+// NewTrustBundleCache creates an empty cache. Pass the returned value to
+// workloadapi.Client.WatchX509Context to start populating it.
+func NewTrustBundleCache(logger *zap.Logger) *TrustBundleCache {
+	return &TrustBundleCache{logger: logger}
+}
+
+// Get returns a defensive copy of the cached PEM bytes.
+// Returns nil if no update has been received yet.
+func (c *TrustBundleCache) Get() []byte {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if len(c.pemBytes) == 0 {
+		return nil
+	}
+	return append([]byte(nil), c.pemBytes...)
+}
+
+// OnX509ContextUpdate implements workloadapi.X509ContextWatcher. Called by
+// go-spiffe whenever the agent pushes a new X.509 context — on initial
+// subscribe, on SVID rotation, on bundle/CA change, on entry change, and on
+// post-reconnect re-subscribe.
+func (c *TrustBundleCache) OnX509ContextUpdate(x509Ctx *workloadapi.X509Context) {
+	if x509Ctx == nil || x509Ctx.Bundles == nil {
+		return
+	}
+
+	var localPemBytes []byte
+	for _, bundle := range x509Ctx.Bundles.Bundles() {
+		for _, cert := range bundle.X509Authorities() {
+			b := pem.EncodeToMemory(&pem.Block{
+				Type:  "CERTIFICATE",
+				Bytes: cert.Raw,
+			})
+			localPemBytes = append(localPemBytes, b...)
+		}
+	}
+
+	c.mu.Lock()
+	c.pemBytes = localPemBytes
+	c.mu.Unlock()
+}
+
+// OnX509ContextWatchError implements workloadapi.X509ContextWatcher. Logged at
+// info level — go-spiffe handles reconnect internally, so these are
+// transient. An operator alarming on sustained errors should look at the
+// process logs.
+func (c *TrustBundleCache) OnX509ContextWatchError(err error) {
+	if c.logger != nil {
+		c.logger.Info("workload API watcher transient error", zap.Error(err))
+	}
+}

--- a/internal/service/runner.go
+++ b/internal/service/runner.go
@@ -2,13 +2,10 @@ package service
 
 import (
 	"context"
-	"encoding/json"
 	"crypto/tls"
-	"encoding/pem"
 	"fmt"
 	"net"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -16,8 +13,9 @@ import (
 	proto "github.com/spiffe/spire-identity-exchange/api"
 	"github.com/spiffe/spire-identity-exchange/internal/config"
 	"github.com/spiffe/spire-identity-exchange/internal/metrics"
+	"github.com/spiffe/spire-identity-exchange/internal/service/rest"
+	"github.com/spiffe/spire-identity-exchange/internal/spireagent/delegated"
 	"github.com/spiffe/spire-identity-exchange/internal/validator"
-	"github.com/spiffe/spire-identity-exchange/pkg/validator/github"
 	server_util "github.com/spiffe/spire/cmd/spire-server/util"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -42,46 +40,17 @@ const (
 	httpMaxRequestBodyBytes int64 = 256 * 1024
 )
 
-// trustBundleCache implements the workloadapi.X509ContextWatcher interface.
-type trustBundleCache struct {
-	mu       sync.RWMutex
-	pemBytes []byte
+// RESTDeps holds the dependencies the REST surface needs that are constructed
+// in main.go (validators come from operator config; the delegated client
+// needs a live socket path). Passing them through Run keeps runner.go a pure
+// lifecycle file.
+type RESTDeps struct {
+	// Plugins maps a path-param name (e.g. "github") to a validator + selector
+	// generator pair. Population happens in main.go from operator config.
+	Plugins rest.PluginSet
 }
 
-func (c *trustBundleCache) Get() []byte {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return append([]byte(nil), c.pemBytes...)
-}
-
-// OnX509ContextUpdate matches the real workloadapi.X509ContextWatcher interface signature.
-func (c *trustBundleCache) OnX509ContextUpdate(x509Ctx *workloadapi.X509Context) {
-	if x509Ctx == nil || x509Ctx.Bundles == nil {
-		return
-	}
-
-	var localPemBytes []byte
-	for _, bundle := range x509Ctx.Bundles.Bundles() {
-		for _, cert := range bundle.X509Authorities() {
-			b := pem.EncodeToMemory(&pem.Block{
-				Type:  "CERTIFICATE",
-				Bytes: cert.Raw,
-			})
-			localPemBytes = append(localPemBytes, b...)
-		}
-	}
-
-	c.mu.Lock()
-	c.pemBytes = localPemBytes
-	c.mu.Unlock()
-}
-
-// OnX509ContextWatchError matches the real workloadapi.X509ContextWatcher interface signature.
-func (c *trustBundleCache) OnX509ContextWatchError(err error) {
-	// Hooks error channel updates from the streaming socket connection context gracefully
-}
-
-// Run runs spire-identity-exchange gRPC server (and optionally HTTP gateway) and waits for
+// Run runs spire-identity-exchange gRPC server (and optionally HTTP REST server) and waits for
 // termination signals. Pass nil for a validator to disable that auth method.
 // Returns the first error encountered during startup or runtime so the caller can exit
 // non-zero — a swallowed bind/TLS failure looks identical to a clean shutdown to a
@@ -92,10 +61,11 @@ func Run(
 	spireClient server_util.ServerClient,
 	githubOIDCValidator validator.TokenValidator,
 	k8sSATokenValidator validator.TokenValidator,
+	restDeps RESTDeps,
 	metrics metrics.Metrics,
 	logger *zap.Logger,
 ) error {
-	if err := runSpireIdentityExchangeServer(ctx, cfg, spireClient, githubOIDCValidator, k8sSATokenValidator, metrics, logger); err != nil {
+	if err := runSpireIdentityExchangeServer(ctx, cfg, spireClient, githubOIDCValidator, k8sSATokenValidator, restDeps, metrics, logger); err != nil {
 		logger.Error("spire-identity-exchange error", zap.Error(err))
 		return err
 	}
@@ -103,14 +73,15 @@ func Run(
 	return nil
 }
 
-// runSpireIdentityExchangeServer starts the gRPC server and, if httpGatewayPort is set,
-// also an HTTP/REST gateway on a separate port backed by the same in-process handler.
+// runSpireIdentityExchangeServer starts the gRPC server and, if restPort is set,
+// also an HTTP REST server on a separate port backed by handlers in the rest package.
 func runSpireIdentityExchangeServer(
 	ctx context.Context,
 	cfg *config.SpireIdentityExchangeConfig,
 	spireClient server_util.ServerClient,
 	githubOIDCValidator validator.TokenValidator,
 	k8sSATokenValidator validator.TokenValidator,
+	restDeps RESTDeps,
 	metrics metrics.Metrics,
 	logger *zap.Logger,
 ) error {
@@ -165,32 +136,41 @@ func runSpireIdentityExchangeServer(
 		errCh <- grpcServer.Serve(listener)
 	}()
 
-	// --- Initialize go-spiffe background watcher stream ---
-	cache := &trustBundleCache{}
+	// --- REST server (optional) ---
+	var (
+		httpServer      *http.Server
+		delegatedClient *delegated.Client
+	)
 	if cfg.Server.RestPort != 0 {
-		socketAddr := fmt.Sprintf("unix://%s", cfg.SPIRE.AgentWorkloadSocketPath)
-		logger.Info("Initializing go-spiffe workload API stream client", zap.String("socket_path", socketAddr))
+		// Trust bundle cache fed by Main agent's Workload API.
+		trustBundle := rest.NewTrustBundleCache(logger)
+		socketAddr := "unix://" + cfg.SPIRE.AgentWorkloadSocketPath
+		logger.Info("initializing workload API watcher", zap.String("socket_path", socketAddr))
 
-		client, err := workloadapi.New(ctx, workloadapi.WithAddr(socketAddr))
+		wlaClient, err := workloadapi.New(ctx, workloadapi.WithAddr(socketAddr))
 		if err != nil {
 			return fmt.Errorf("failed to create workload API client: %w", err)
 		}
-
 		go func() {
-			defer client.Close()
-			if watchErr := client.WatchX509Context(ctx, cache); watchErr != nil {
-				logger.Error("SPIRE trust bundle context watcher runtime error", zap.Error(watchErr))
+			defer wlaClient.Close()
+			if watchErr := wlaClient.WatchX509Context(ctx, trustBundle); watchErr != nil {
+				logger.Error("workload API watcher stopped with error", zap.Error(watchErr))
 			}
 		}()
-	}
 
-	// --- Custom Hand-Crafted REST API ---
-	var httpServer *http.Server
-	if cfg.Server.RestPort != 0 {
-		mux := http.NewServeMux()
+		// Delegated Identity client to SIX's admin socket.
+		logger.Info("connecting to delegated identity socket", zap.String("socket_path", cfg.SPIRE.AgentDelegatedSocketPath))
+		delegatedClient, err = delegated.New(cfg.SPIRE.AgentDelegatedSocketPath)
+		if err != nil {
+			return fmt.Errorf("failed to create delegated identity client: %w", err)
+		}
 
-		mux.HandleFunc("GET /api/v1/trustbundle/x509", handleTrustBundleX509(cache, logger))
-		mux.HandleFunc("POST /api/v1/svid/{plugin}/x509", handleGetX509SVID(cache, logger))
+		mux := rest.NewMux(rest.Deps{
+			TrustBundle: trustBundle,
+			Delegated:   delegatedClient,
+			Plugins:     restDeps.Plugins,
+			Logger:      logger,
+		})
 
 		httpServer = &http.Server{
 			Addr:              fmt.Sprintf(":%d", cfg.Server.RestPort),
@@ -214,13 +194,16 @@ func runSpireIdentityExchangeServer(
 
 	// stopStarted tears down anything we already brought up. Used when one server fails to
 	// start while the other is already listening — without this, a bind failure on the HTTP
-	// gateway would leak the gRPC listener (port stays bound, supervisor restarts re-fail).
+	// REST server would leak the gRPC listener (port stays bound, supervisor restarts re-fail).
 	stopStarted := func() {
 		grpcServer.Stop()
 		if httpServer != nil {
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 			defer cancel()
 			_ = httpServer.Shutdown(shutdownCtx)
+		}
+		if delegatedClient != nil {
+			_ = delegatedClient.Close()
 		}
 	}
 
@@ -272,73 +255,12 @@ func runSpireIdentityExchangeServer(
 			grpcServer.Stop()
 		}
 
+		if delegatedClient != nil {
+			_ = delegatedClient.Close()
+		}
 		return nil
 
 	case err := <-errCh:
 		return fmt.Errorf("server runtime error: %w", err)
-	}
-}
-
-// handleTrustBundleX509 reads instantly from the pre-baked cache on HTTP request hit.
-func handleTrustBundleX509(cache *trustBundleCache, logger *zap.Logger) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		pemBytes := cache.Get()
-
-		if len(pemBytes) == 0 {
-			logger.Warn("Trust bundle requested but cache is empty or warming up")
-			http.Error(w, "Trust bundle warming up or unavailable", http.StatusServiceUnavailable)
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/x-pem-file")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(pemBytes)
-	}
-}
-
-// handleGetX509SVID Verify the token from the user and return 1 valid x509 svid if available including chain
-func handleGetX509SVID(cache *trustBundleCache, logger *zap.Logger) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		//w.Header().Set("Content-Type", "application/x-pem-file")
-		w.Header().Set("Content-Type", "plain/text")
-		w.WriteHeader(http.StatusOK)
-
-		authHeader := r.Header.Get("Authorization")
-		if authHeader == "" {
-			http.Error(w, "Missing Authorization Header", http.StatusUnauthorized)
-			return
-		}
-
-		if !strings.HasPrefix(strings.ToLower(authHeader), "bearer ") {
-			http.Error(w, "Invalid Authorization Header Format", http.StatusUnauthorized)
-			return
-		}
-
-		token := strings.TrimSpace(authHeader[7:])
-		if token == "" {
-			http.Error(w, "Empty Token", http.StatusUnauthorized)
-			return
-		}
-
-		cfg := github.Config{
-			AllowedRepositories: []string{"spiffe/spire-identity-exchange"},
-			Audiences:           []string{"spire-identity-exchange"},
-		}
-
-		validator, err := github.NewValidator(cfg)
-		if err != nil {
-			logger.Warn("Failed to init validator", zap.Error(err))
-			http.Error(w, "spire-identity-exchange is currently unavailable", http.StatusServiceUnavailable)
-			return
-		}
-		claims, err := validator.Validate(r.Context(), token)
-		if err != nil {
-			logger.Info("Failed to validate", zap.Error(err))
-			http.Error(w, "Failed to validate your token", http.StatusUnauthorized)
-			return
-		}
-		selectors := validator.GenerateSelectors(claims)
-		selectorsJSON, _ := json.Marshal(selectors)
-		_, _ = w.Write([]byte("Hello: " + r.PathValue("plugin")+" " + string(selectorsJSON) ))
 	}
 }

--- a/internal/service/runner_test.go
+++ b/internal/service/runner_test.go
@@ -48,7 +48,7 @@ func TestRunSpireIdentityExchangeServer_NilConfig(t *testing.T) {
 	ctx := context.Background()
 	mockValidator := &MockValidator{}
 
-	err := runSpireIdentityExchangeServer(ctx, nil, &MockServerClient{}, mockValidator, nil, nil, logger)
+	err := runSpireIdentityExchangeServer(ctx, nil, &MockServerClient{}, mockValidator, nil, RESTDeps{}, nil, logger)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "configuration is nil")
@@ -75,7 +75,7 @@ func TestRunSpireIdentityExchangeServer_InvalidValidatorConfig(t *testing.T) {
 	}
 	mockValidator := &MockValidator{}
 
-	err := runSpireIdentityExchangeServer(ctx, cfg, &MockServerClient{}, mockValidator, nil, nil, logger)
+	err := runSpireIdentityExchangeServer(ctx, cfg, &MockServerClient{}, mockValidator, nil, RESTDeps{}, nil, logger)
 
 	// With an empty issuer, the validator creation should fail
 	// However, if it doesn't, the cancelled context will cause the server to shut down

--- a/internal/spireagent/delegated/client.go
+++ b/internal/spireagent/delegated/client.go
@@ -1,0 +1,211 @@
+// Package delegated wraps the SPIRE Agent Delegated Identity API in a small
+// one-shot client tailored to the spire-identity-exchange REST flow.
+//
+// The Delegated Identity API is a streaming RPC; this wrapper takes the first
+// message off SubscribeToX509SVIDs and closes the stream, which matches the
+// "validate token → fetch SVID → return" shape of the REST handler. Keeping
+// long-lived subscriptions open per request would not buy anything: the
+// exchange terminates the request as soon as it has a cert to return.
+//
+// The transport is gRPC over a Unix domain socket; security is provided by
+// the kernel (SO_PEERCRED) plus the agent's authorized_delegates check on
+// the caller's SPIFFE ID. No client cert is presented — the listener's
+// filesystem permissions are the only network-level defense.
+package delegated
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	delegatedidentityv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/delegatedidentity/v1"
+	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+// ErrNoMatchingEntry indicates the agent had no entry whose selectors are a
+// subset of those requested. Translated to HTTP 404 by callers.
+var ErrNoMatchingEntry = errors.New("no registration entry matches the requested selectors")
+
+// ErrPermissionDenied indicates the caller's SPIFFE ID is not in the agent's
+// authorized_delegates configuration. Translated to HTTP 503 by callers — it
+// is an operator misconfiguration, not a request-level error.
+var ErrPermissionDenied = errors.New("caller not in authorized_delegates")
+
+// ErrUnavailable indicates the agent's delegated socket is not reachable.
+// Translated to HTTP 503 by callers.
+var ErrUnavailable = errors.New("delegated identity API unavailable")
+
+// X509SVID is the wire-decoded result of an X.509 SVID fetch.
+type X509SVID struct {
+	SpiffeID   string
+	CertChain  [][]byte // ASN.1 DER, leaf first
+	PrivateKey []byte   // PKCS#8 DER
+	ExpiresAt  time.Time
+	Hint       string
+}
+
+// JWTSVID is the wire-decoded result of a JWT SVID fetch.
+type JWTSVID struct {
+	SpiffeID  string
+	Token     string
+	ExpiresAt time.Time
+	Hint      string
+}
+
+// Client is a long-lived handle to the SPIRE Agent's Delegated Identity API.
+// One Client per process is sufficient; gRPC manages the underlying connection
+// (reconnects, keepalives).
+type Client struct {
+	conn *grpc.ClientConn
+	api  delegatedidentityv1.DelegatedIdentityClient
+}
+
+// New opens a connection to the agent's delegated socket. The socket path must
+// be an absolute filesystem path; it is opened as `unix://<path>`.
+//
+// The connection is lazy — `New` does not block on the socket being reachable.
+// The first RPC will surface ErrUnavailable if the agent is not running.
+func New(socketPath string) (*Client, error) {
+	if socketPath == "" {
+		return nil, errors.New("delegated socket path is required")
+	}
+	conn, err := grpc.NewClient(
+		"unix://"+socketPath,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("dial delegated socket %s: %w", socketPath, err)
+	}
+	return &Client{
+		conn: conn,
+		api:  delegatedidentityv1.NewDelegatedIdentityClient(conn),
+	}, nil
+}
+
+// Close releases the underlying gRPC connection.
+func (c *Client) Close() error {
+	if c == nil || c.conn == nil {
+		return nil
+	}
+	return c.conn.Close()
+}
+
+// FetchX509SVID asks the agent for an X.509-SVID whose entry selectors are a
+// subset of those provided. The call uses the streaming SubscribeToX509SVIDs
+// RPC under the hood, takes the first message, and closes the stream.
+//
+// Returns ErrNoMatchingEntry if the agent's cache has no matching entry —
+// either the entries haven't propagated yet, the selectors don't match, or
+// the entries are parented elsewhere and SIX never received them.
+func (c *Client) FetchX509SVID(ctx context.Context, selectors []*types.Selector) (*X509SVID, error) {
+	if len(selectors) == 0 {
+		return nil, errors.New("at least one selector is required")
+	}
+
+	// A short cancel context guards against the stream hanging if the agent
+	// accepts the connection but never sends a message. The first message is
+	// the agent's snapshot of matching SVIDs, which it should produce
+	// immediately after attesting the caller.
+	streamCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	stream, err := c.api.SubscribeToX509SVIDs(streamCtx, &delegatedidentityv1.SubscribeToX509SVIDsRequest{
+		Selectors: selectors,
+	})
+	if err != nil {
+		return nil, translateRPCError(err)
+	}
+
+	resp, err := stream.Recv()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, ErrNoMatchingEntry
+		}
+		return nil, translateRPCError(err)
+	}
+
+	if len(resp.X509Svids) == 0 {
+		return nil, ErrNoMatchingEntry
+	}
+
+	first := resp.X509Svids[0]
+	if first == nil || first.X509Svid == nil {
+		return nil, fmt.Errorf("delegated identity API returned nil SVID")
+	}
+
+	return &X509SVID{
+		SpiffeID:   spiffeIDString(first.X509Svid.Id),
+		CertChain:  first.X509Svid.CertChain,
+		PrivateKey: first.X509SvidKey,
+		ExpiresAt:  time.Unix(first.X509Svid.ExpiresAt, 0),
+		Hint:       first.X509Svid.Hint,
+	}, nil
+}
+
+// FetchJWTSVID asks the agent for a JWT-SVID matching the selectors and
+// audiences. This is a unary RPC; no stream handling required.
+func (c *Client) FetchJWTSVID(ctx context.Context, selectors []*types.Selector, audiences []string) (*JWTSVID, error) {
+	if len(selectors) == 0 {
+		return nil, errors.New("at least one selector is required")
+	}
+	if len(audiences) == 0 {
+		return nil, errors.New("at least one audience is required")
+	}
+
+	resp, err := c.api.FetchJWTSVIDs(ctx, &delegatedidentityv1.FetchJWTSVIDsRequest{
+		Audience:  audiences,
+		Selectors: selectors,
+	})
+	if err != nil {
+		return nil, translateRPCError(err)
+	}
+
+	if len(resp.Svids) == 0 {
+		return nil, ErrNoMatchingEntry
+	}
+
+	first := resp.Svids[0]
+	if first == nil {
+		return nil, fmt.Errorf("delegated identity API returned nil JWT-SVID")
+	}
+
+	return &JWTSVID{
+		SpiffeID:  spiffeIDString(first.Id),
+		Token:     first.Token,
+		ExpiresAt: time.Unix(first.ExpiresAt, 0),
+		Hint:      first.Hint,
+	}, nil
+}
+
+func spiffeIDString(id *types.SPIFFEID) string {
+	if id == nil {
+		return ""
+	}
+	return "spiffe://" + id.TrustDomain + id.Path
+}
+
+// translateRPCError maps gRPC status codes onto the package-level sentinel
+// errors so HTTP handlers can pick the right status code without parsing the
+// gRPC error string.
+func translateRPCError(err error) error {
+	st, ok := status.FromError(err)
+	if !ok {
+		return err
+	}
+	switch st.Code() {
+	case codes.PermissionDenied:
+		return fmt.Errorf("%w: %s", ErrPermissionDenied, st.Message())
+	case codes.NotFound, codes.InvalidArgument:
+		return fmt.Errorf("%w: %s", ErrNoMatchingEntry, st.Message())
+	case codes.Unavailable, codes.DeadlineExceeded:
+		return fmt.Errorf("%w: %s", ErrUnavailable, st.Message())
+	default:
+		return err
+	}
+}

--- a/tests/integration/github/default.json
+++ b/tests/integration/github/default.json
@@ -13,6 +13,7 @@
   "spire": {
     "unixSocketPath": "/var/run/spire/server/sockets/${SYSTEMD_INSTANCE}/private/api.sock",
     "agentWorkloadSocketPath": "/var/run/spire/agent/sockets/${SYSTEMD_INSTANCE}/public/api.sock",
+    "agentDelegatedSocketPath": "/var/run/spire/agent/sockets/six/admin/api.sock",
     "trustDomain": "${SPIFFE_TRUST_DOMAIN}",
     "svidTTL": "5m"
   },

--- a/tests/integration/github/manifests/six-github-job.yaml
+++ b/tests/integration/github/manifests/six-github-job.yaml
@@ -3,7 +3,7 @@ kind: ClusterStaticEntry
 metadata:
   name: six-github-test
 spec:
-  parentID: spiffe://${SPIFFE_TRUST_DOMAIN}/spire/agent/x509pop/spire-identity-exchange
+  parentID: spiffe://${SPIFFE_TRUST_DOMAIN}/spire-identity-exchange
   spiffeID: spiffe://${SPIFFE_TRUST_DOMAIN}/github/test
   selectors:
   - github_actions:workflow_ref:repo:spiffe/spire-identity-exchange

--- a/tests/integration/github/manifests/six-spire-identity-exchange.yaml
+++ b/tests/integration/github/manifests/six-spire-identity-exchange.yaml
@@ -2,9 +2,9 @@
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterStaticEntry
 metadata:
-  name: node1-spire-identity-exchange
+  name: six-spire-identity-exchange
 spec:
-  parentID: spiffe://${SPIFFE_TRUST_DOMAIN}/spire/agent/x509pop/spire-identity-exchange
+  parentID: spiffe://${SPIFFE_TRUST_DOMAIN}/spire-identity-exchange
   spiffeID: spiffe://${SPIFFE_TRUST_DOMAIN}/spire-identity-exchange
   selectors:
   - systemd:id:spire-identity-exchange@main.service

--- a/tests/integration/github/run-tests.sh
+++ b/tests/integration/github/run-tests.sh
@@ -156,4 +156,42 @@ go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
 
 diff -u <(curl https://localhost:8444/api/v1/trustbundle/x509 --cacert /etc/spire/identity-exchange/main/certs/server.pem -s) <(sudo spire-server bundle show)
 
-curl -H "Authorization: Bearer ${GITHUB_TOKEN}" -X POST https://localhost:8444/api/v1/svid/github/x509 --cacert /etc/spire/identity-exchange/main/certs/server.pem -s
+# --- Delegated REST X509 SVID issuance end-to-end ---
+# Wait for SIX agent's cache to populate with the alias-parented entries.
+# After SIX attests, entries flow from server → agent over a few seconds.
+DELEGATED_RESPONSE=""
+DELEGATED_ELAPSED=0
+DELEGATED_MAX_WAIT=30
+while [ ${DELEGATED_ELAPSED} -lt ${DELEGATED_MAX_WAIT} ]; do
+  if DELEGATED_RESPONSE=$(curl -fsS -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+      -X POST https://localhost:8444/api/v1/svid/github/x509 \
+      --cacert /etc/spire/identity-exchange/main/certs/server.pem 2>/dev/null); then
+    break
+  fi
+  sleep 1
+  ((DELEGATED_ELAPSED++)) || true
+done
+
+if [ -z "${DELEGATED_RESPONSE}" ]; then
+  echo "::error::delegated SVID endpoint did not return a response within ${DELEGATED_MAX_WAIT}s"
+  exit 1
+fi
+
+echo "${DELEGATED_RESPONSE}" | jq -e '.spiffeId' >/dev/null || {
+  echo "::error::delegated response missing spiffeId: ${DELEGATED_RESPONSE}"; exit 1
+}
+
+echo "${DELEGATED_RESPONSE}" | jq -r '.cert'   > /tmp/svid.pem
+echo "${DELEGATED_RESPONSE}" | jq -r '.bundle' > /tmp/bundle.pem
+
+# Issued SVID has a SPIFFE URI SAN.
+openssl x509 -in /tmp/svid.pem -text -noout | grep -q "URI:spiffe://" || {
+  echo "::error::issued cert is missing a SPIFFE URI SAN"; exit 1
+}
+
+# Issued SVID chains to the returned trust bundle.
+openssl verify -CAfile /tmp/bundle.pem /tmp/svid.pem || {
+  echo "::error::issued cert does not chain to the returned trust bundle"; exit 1
+}
+
+echo "delegated X509 SVID issuance verified end-to-end"


### PR DESCRIPTION
## Summary

Wire the REST `POST /api/v1/svid/{plugin}/x509` endpoint into the SPIRE Agent's Delegated Identity API on a SIX-style admin socket. End-to-end flow:

```
caller (JWT) → validate → selectors → SIX agent → SVID → JSON response
```

Builds on PR #20 (test framework) and PR #24 (REST scaffolding). Picks up where Kevin left off in #24 ("It goes just far enough to get the selectors") and adds the delegated client + handler completion + manifest fixes to make it work end-to-end.

## What changed

### New code

- **`internal/spireagent/delegated/client.go`** — one-shot wrapper around `SubscribeToX509SVIDs` / `FetchJWTSVIDs` over UDS. Maps gRPC codes onto sentinel errors so HTTP handlers can pick the right status code.

- **`internal/service/rest/`** — handlers extracted out of `runner.go` into a focused package:
  - `trustbundle.go` — `TrustBundleCache` (moved from runner.go)
  - `plugins.go` — `PluginSet` registry keyed by URL path-param name
  - `handlers.go` — REST handlers
  - `server.go` — `NewMux` factory

- **Plugin registry** (`main.go` → `rest.PluginSet`) — built once at startup from operator config, mapping `{plugin}` path-param (e.g. `github`) to a `(TokenValidator, SelectorGenerator)` pair. Replaces the per-request `github.NewValidator(...)` with hardcoded allow-list from #24.

### Handler rewrite

`handleGetX509SVID`:
- Reuses the configured validator from `main.go` instead of constructing inline.
- Returns JSON `{spiffeId, cert, key, bundle, expiresAt}` instead of `"Hello: <plugin>"` stub.
- Maps errors to proper status codes: 401 (bad token) / 400 (unknown plugin or no selectors) / 404 (no matching entry) / 503 (delegated unavailable) / 500 (other).
- Fixes the `WriteHeader(StatusOK)`-before-validation bug that made all errors return 200.
- Drops the hardcoded `AllowedRepositories: ["spiffe/spire-identity-exchange"]` and `Content-Type: "plain/text"` typo.

### Config

New `spire.agentDelegatedSocketPath` field, required when `server.restPort != 0`. Example configs and the integration test `default.json` updated.

### Manifest fixes

- `six-github-job.yaml` — `parentID` now the alias `spiffe://<td>/spire-identity-exchange` (was the bare x509pop node prefix that didn't match any agent's identity).
- `six-spire-identity-exchange.yaml` — same `parentID` fix, plus `metadata.name` renamed from `node1-spire-identity-exchange` to avoid colliding with `node1-spire-identity-exchange.yaml`.

### Integration test

- Real assertion that `POST /api/v1/svid/github/x509` returns a SPIFFE-URI-SAN cert that `openssl verify` confirms chains to the returned trust bundle.
- 30s wait for SIX's cache to populate after attestation.

### Docs

- `docs/spire-agent-integration-plan.md` — design context for Piece A / Piece B.
- `docs/delegated-api-implementation-plan.md` — the implementation plan this PR executes.

## What is intentionally not included

- **CSR support on the delegated path.** Per Kevin's "For now, no csr" — the agent generates the key. CSR remains on the broker (gRPC) path.
- **Per-call TTL.** Delegated Identity API does not honor a per-call TTL; entry TTL applies.
- **Replay cache wrapping on the REST path.** The existing `internal/cache.NewReplayCheckingValidator` targets the internal validator interface; an equivalent for `pkg/validator` is a separate concern. TODO comment added.
- **`SVIDIssuer` abstraction over broker vs delegated.** The broker (gRPC) `MintCertificate` path continues to work unchanged; delegated is only on the REST surface.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass (cache, github-oidc, k8s-sa-token, service, utils, validator packages)
- [ ] Integration test (`tests/integration/github/run-tests.sh`) — runs in CI on this PR
- [ ] End-to-end manual verification: `curl -H "Authorization: Bearer $JWT" -X POST https://localhost:8444/api/v1/svid/github/x509` returns a valid SVID JSON

## Related

- PR #20 — initial test framework (merged)
- PR #24 — initial REST API work (merged)
- This PR — completes the delegated API plumbing started by #24