### PR TITLE
Add configurable purposeMode with shared default for replay cache sco…

### DIFF
--- a/config/config.example-local.json
+++ b/config/config.example-local.json
@@ -1,6 +1,7 @@
 {
   "name": "spire-identity-exchange",
   "logLevel": "info",
+  "purposeMode": "shared",
   "server": {
     "port": 8443,
     "metricsPort": 9090,

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -1,6 +1,7 @@
 {
   "name": "spire-identity-exchange",
   "logLevel": "info",
+  "purposeMode": "shared",
   "server": {
     "port": 8443,
     "metricsPort": 4950,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,13 +38,14 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 }
 
 type SpireIdentityExchangeConfig struct {
-	Name       string           `json:"name"`
-	LogLevel   string           `json:"logLevel"`
-	Server     ServerConfig     `json:"server"`
-	SPIRE      SPIREConfig      `json:"spire"`
-	Auth       AuthConfig       `json:"auth"`
-	GitHubOIDC GitHubOIDCConfig `json:"githubOIDC"`
-	K8sSAToken K8sSATokenConfig `json:"k8sSAToken"`
+	Name        string           `json:"name"`
+	LogLevel    string           `json:"logLevel"`
+	PurposeMode string           `json:"purposeMode"`
+	Server      ServerConfig     `json:"server"`
+	SPIRE       SPIREConfig      `json:"spire"`
+	Auth        AuthConfig       `json:"auth"`
+	GitHubOIDC  GitHubOIDCConfig `json:"githubOIDC"`
+	K8sSAToken  K8sSATokenConfig `json:"k8sSAToken"`
 }
 
 // ServerConfig contains HTTP server configuration
@@ -346,6 +347,14 @@ func (c *SpireIdentityExchangeConfig) Validate() error {
 		case "debug", "info", "warn", "error", "dpanic", "panic", "fatal":
 		default:
 			errs = append(errs, fmt.Errorf("logLevel %q is not a recognized level (debug|info|warn|error|dpanic|panic|fatal)", c.LogLevel))
+		}
+	}
+
+	if c.PurposeMode != "" {
+		switch c.PurposeMode {
+		case "purpose", "shared":
+		default:
+			errs = append(errs, fmt.Errorf("purposeMode %q is not recognized (purpose|shared)", c.PurposeMode))
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -352,7 +352,7 @@ func (c *SpireIdentityExchangeConfig) Validate() error {
 
 	if c.PurposeMode != "" {
 		switch c.PurposeMode {
-		case "purpose", "shared":
+		case string(validator.PurposeModePurpose), string(validator.PurposeModeShared):
 		default:
 			errs = append(errs, fmt.Errorf("purposeMode %q is not recognized (purpose|shared)", c.PurposeMode))
 		}

--- a/internal/service/mintcertificate.go
+++ b/internal/service/mintcertificate.go
@@ -44,7 +44,7 @@ func (h *SpireIdentityExchangeServer) MintCertificateByGithubOIDC(ctx context.Co
 		return nil, status.Error(codes.InvalidArgument, "GithubOIDC is not set")
 	}
 
-	purpose := determinePurpose(req)
+	purpose := h.determinePurpose(req)
 	claims, err := h.githubOIDC.validator.Validate(ctx, githubOIDC.GithubToken, purpose)
 	if err != nil {
 		audit.FailedStage = stageTokenValidation
@@ -83,7 +83,7 @@ func (h *SpireIdentityExchangeServer) MintCertificateByK8sSAToken(ctx context.Co
 		return nil, status.Error(codes.InvalidArgument, "K8sSA is not set")
 	}
 
-	purpose := determinePurpose(req)
+	purpose := h.determinePurpose(req)
 	claims, err := h.k8sSAToken.validator.Validate(ctx, k8sSA.K8SSAToken, purpose)
 	if err != nil {
 		audit.FailedStage = stageTokenValidation
@@ -393,13 +393,15 @@ func (h *SpireIdentityExchangeServer) mintX509SVIDServerKeyGen(
 	}, nil
 }
 
-// determinePurpose derives the replay cache Purpose from the mint request.
-// JWT-SVID requests include audience-scoped hashing; all others default to X.509.
-func determinePurpose(req *proto.MintCertificateRequest) v.Purpose {
+// determinePurpose derives the replay cache Purpose from the mint request,
+// respecting the configured PurposeMode. In "shared" mode, all requests
+// produce the same cache key so a token can only be used once across all
+// SVID types.
+func (h *SpireIdentityExchangeServer) determinePurpose(req *proto.MintCertificateRequest) v.Purpose {
 	if jwtReq := req.GetMintJWTSVIDRequest(); jwtReq != nil {
-		return v.JWTPurpose(jwtReq.GetAudiences())
+		return h.purposeResolver.JWT(jwtReq.GetAudiences())
 	}
-	return v.X509Purpose()
+	return h.purposeResolver.X509()
 }
 
 // populateX509AuditFields extracts the serial number and TTL from an X.509 SVID

--- a/internal/service/oidc_test.go
+++ b/internal/service/oidc_test.go
@@ -346,10 +346,11 @@ func setupTestServer(t *testing.T, templateStr string) (*SpireIdentityExchangeSe
 			spiffeIDTemplate: tmpl,
 			svidTTL:          effectiveTTL(cfg.GitHubOIDC.SVIDTTL, cfg.SPIRE.SVIDTTL),
 		},
-		config:      cfg,
-		logger:      logger,
-		metrics:     testMetrics,
-		trustDomain: spiffeid.RequireTrustDomainFromString(cfg.SPIRE.TrustDomain),
+		config:          cfg,
+		purposeResolver: v.NewPurposeResolver(v.PurposeMode(cfg.PurposeMode)),
+		logger:          logger,
+		metrics:         testMetrics,
+		trustDomain:     spiffeid.RequireTrustDomainFromString(cfg.SPIRE.TrustDomain),
 	}
 
 	return server, mockValidator, mockServerClient, mockSVIDClient
@@ -942,10 +943,11 @@ func TestMintCertificateByGithubOIDC_WithDifferentTTL(t *testing.T) {
 			spiffeIDTemplate: tmpl,
 			svidTTL:          effectiveTTL(cfg.GitHubOIDC.SVIDTTL, cfg.SPIRE.SVIDTTL),
 		},
-		config:      cfg,
-		logger:      logger,
-		metrics:     testMetrics,
-		trustDomain: spiffeid.RequireTrustDomainFromString(cfg.SPIRE.TrustDomain),
+		config:          cfg,
+		purposeResolver: v.NewPurposeResolver(v.PurposeMode(cfg.PurposeMode)),
+		logger:          logger,
+		metrics:         testMetrics,
+		trustDomain:     spiffeid.RequireTrustDomainFromString(cfg.SPIRE.TrustDomain),
 	}
 
 	spiffeIDStr := "spiffe://example.org/github/example-org/test-repo"

--- a/internal/service/runner.go
+++ b/internal/service/runner.go
@@ -221,7 +221,8 @@ func runSpireIdentityExchangeServer(
 
 		mux := http.NewServeMux()
 		mux.HandleFunc("GET /api/v1/trustbundle/x509", handleTrustBundleX509(cache, logger))
-		mux.HandleFunc("POST /api/v1/svid/{stack}/x509", handleGetX509SVID(cfg, cache, delegatedClient, logger))
+		purposeResolver := validator.NewPurposeResolver(validator.PurposeMode(cfg.PurposeMode))
+		mux.HandleFunc("POST /api/v1/svid/{stack}/x509", handleGetX509SVID(cfg, cache, delegatedClient, purposeResolver, logger))
 
 		httpServer = &http.Server{
 			Addr:              fmt.Sprintf(":%d", cfg.Server.RestPort),
@@ -361,7 +362,7 @@ type x509SVIDResponse struct {
 //   - delegated client found no matching entry → 404
 //   - delegated client unavailable / denied  → 503
 //   - any other error                        → 500
-func handleGetX509SVID(cfg *config.SpireIdentityExchangeConfig, cache *trustBundleCache, dc *delegated.Client, logger *zap.Logger) http.HandlerFunc {
+func handleGetX509SVID(cfg *config.SpireIdentityExchangeConfig, cache *trustBundleCache, dc *delegated.Client, pr *validator.PurposeResolver, logger *zap.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token, err := extractBearerToken(r)
 		if err != nil {
@@ -380,7 +381,7 @@ func handleGetX509SVID(cfg *config.SpireIdentityExchangeConfig, cache *trustBund
 			return
 		}
 
-		claims, err := v.Validate(r.Context(), token, validator.X509Purpose())
+		claims, err := v.Validate(r.Context(), token, pr.X509())
 		if err != nil {
 			logger.Info("token validation failed", zap.String("stack", stack), zap.Error(err))
 			http.Error(w, "Invalid token", http.StatusUnauthorized)

--- a/internal/service/server.go
+++ b/internal/service/server.go
@@ -25,13 +25,14 @@ type authHandler struct {
 // SpireIdentityExchangeServer is the server for the spire-identity-exchange service.
 type SpireIdentityExchangeServer struct {
 	proto.UnimplementedSpireIdentityExchangeApiServer
-	spireClient server_util.ServerClient
-	githubOIDC  *authHandler // nil if not configured
-	k8sSAToken  *authHandler // nil if not configured
-	config      *config.SpireIdentityExchangeConfig
-	metrics     metrics.Metrics
-	logger      *zap.Logger
-	trustDomain spiffeid.TrustDomain
+	spireClient     server_util.ServerClient
+	githubOIDC      *authHandler // nil if not configured
+	k8sSAToken      *authHandler // nil if not configured
+	config          *config.SpireIdentityExchangeConfig
+	purposeResolver *v.PurposeResolver
+	metrics         metrics.Metrics
+	logger          *zap.Logger
+	trustDomain     spiffeid.TrustDomain
 }
 
 // NewGRPCHandler creates a new GRPC server handler.
@@ -50,11 +51,12 @@ func NewGRPCHandler(
 	}
 
 	server := &SpireIdentityExchangeServer{
-		spireClient: spireClient,
-		trustDomain: trustDomain,
-		config:      cfg,
-		metrics:     metrics,
-		logger:      logger,
+		spireClient:     spireClient,
+		trustDomain:     trustDomain,
+		config:          cfg,
+		purposeResolver: v.NewPurposeResolver(v.PurposeMode(cfg.PurposeMode)),
+		metrics:         metrics,
+		logger:          logger,
 	}
 
 	if githubOIDCValidator != nil {

--- a/pkg/validator/purpose.go
+++ b/pkg/validator/purpose.go
@@ -25,8 +25,8 @@ const (
 // Purpose identifies the intended use of a validated token for replay cache
 // isolation. Different purposes produce distinct replay cache keys so that
 // the same token can be used for multiple SVID types without false replay
-// detection. Use the provided constructors (X509Purpose, JWTPurpose) to
-// create values.
+// detection. Use the provided constructors (X509Purpose, JWTPurpose,
+// SharedPurpose) or a PurposeResolver to create values.
 type Purpose struct {
 	value string
 }

--- a/pkg/validator/purpose.go
+++ b/pkg/validator/purpose.go
@@ -7,6 +7,21 @@ import (
 	"strings"
 )
 
+// PurposeMode controls how the replay cache scopes token reuse.
+type PurposeMode string
+
+const (
+	// PurposeModePurpose allows the same token to be used for different SVID
+	// types (e.g. one X.509 and one JWT-SVID). Each purpose gets its own
+	// replay cache key.
+	PurposeModePurpose PurposeMode = "purpose"
+
+	// PurposeModeShared restricts a token to a single use across all SVID
+	// types. The replay cache key is the same regardless of purpose, so a
+	// token used for X.509 cannot be reused for JWT-SVID.
+	PurposeModeShared PurposeMode = "shared"
+)
+
 // Purpose identifies the intended use of a validated token for replay cache
 // isolation. Different purposes produce distinct replay cache keys so that
 // the same token can be used for multiple SVID types without false replay
@@ -30,6 +45,44 @@ func JWTPurpose(audiences []string) Purpose {
 	slices.Sort(sorted)
 	h := sha256.Sum256([]byte(strings.Join(sorted, "\x00")))
 	return Purpose{value: "jwt:" + hex.EncodeToString(h[:])}
+}
+
+// SharedPurpose returns a Purpose that produces a single cache key for all
+// SVID types. Use this when the deployment requires strict single-use tokens.
+func SharedPurpose() Purpose {
+	return Purpose{value: "shared"}
+}
+
+// PurposeResolver returns the appropriate Purpose for a given request context.
+// In "purpose" mode it delegates to the type-specific constructors; in "shared"
+// mode it always returns SharedPurpose().
+type PurposeResolver struct {
+	mode PurposeMode
+}
+
+// NewPurposeResolver creates a resolver for the given mode.
+// An empty or unrecognized mode defaults to PurposeModeShared.
+func NewPurposeResolver(mode PurposeMode) *PurposeResolver {
+	if mode != PurposeModePurpose {
+		mode = PurposeModeShared
+	}
+	return &PurposeResolver{mode: mode}
+}
+
+// X509 returns the Purpose for X.509 SVID issuance under this resolver's mode.
+func (r *PurposeResolver) X509() Purpose {
+	if r.mode == PurposeModeShared {
+		return SharedPurpose()
+	}
+	return X509Purpose()
+}
+
+// JWT returns the Purpose for JWT-SVID issuance under this resolver's mode.
+func (r *PurposeResolver) JWT(audiences []string) Purpose {
+	if r.mode == PurposeModeShared {
+		return SharedPurpose()
+	}
+	return JWTPurpose(audiences)
 }
 
 // String returns the cache-key fragment for this purpose.

--- a/pkg/validator/purpose_test.go
+++ b/pkg/validator/purpose_test.go
@@ -35,3 +35,40 @@ func TestJWTPurpose_DoesNotMutateInput(t *testing.T) {
 	_ = JWTPurpose(input)
 	assert.Equal(t, original, input, "JWTPurpose should not mutate the input slice")
 }
+
+func TestSharedPurpose(t *testing.T) {
+	p := SharedPurpose()
+	assert.Equal(t, "shared", p.String())
+}
+
+func TestPurposeResolver_PurposeMode(t *testing.T) {
+	r := NewPurposeResolver(PurposeModePurpose)
+
+	x509 := r.X509()
+	jwt := r.JWT([]string{"api.example.com"})
+
+	assert.Equal(t, "x509", x509.String())
+	assert.Contains(t, jwt.String(), "jwt:")
+	assert.NotEqual(t, x509.String(), jwt.String(), "purpose mode should produce distinct keys")
+}
+
+func TestPurposeResolver_SharedMode(t *testing.T) {
+	r := NewPurposeResolver(PurposeModeShared)
+
+	x509 := r.X509()
+	jwt := r.JWT([]string{"api.example.com"})
+
+	assert.Equal(t, "shared", x509.String())
+	assert.Equal(t, "shared", jwt.String())
+	assert.Equal(t, x509.String(), jwt.String(), "shared mode should produce identical keys")
+}
+
+func TestPurposeResolver_DefaultMode(t *testing.T) {
+	r := NewPurposeResolver("")
+
+	x509 := r.X509()
+	jwt := r.JWT([]string{"api.example.com"})
+
+	assert.Equal(t, "shared", x509.String(), "empty mode should default to shared mode")
+	assert.Equal(t, "shared", jwt.String(), "empty mode should default to shared mode")
+}


### PR DESCRIPTION
## Summary
- Add `purposeMode` config option ("purpose" | "shared") to control replay cache token reuse scope
- "shared" (default): single-use tokens across all SVID types
- "purpose": allows same token for different SVID types (X.509 and JWT)
- Resolves #23

## Test plan
- [x] `go build ./...` pass
- [x] `go test ./...` pass
- [x] Default mode ("shared") produces identical cache keys for X.509 and JWT
- [x] "purpose" mode produces distinct cache keys per SVID type