### PR TITLE
Add mock K8s API server + CI integration test for K8s SA token validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 config/certs/
 certs/
+/mock-k8s-api

--- a/examples/mock-k8s-api/main.go
+++ b/examples/mock-k8s-api/main.go
@@ -1,0 +1,338 @@
+// mock-k8s-api is a local development tool that simulates the K8s API server's
+// TokenReview endpoint. It:
+//   - generates a CA + server TLS cert pair on startup
+//   - generates a placeholder client cert/key (the mock does not actually verify
+//     the client, but spire-identity-exchange's TokenReview client config
+//     requires CertFile/KeyFile to be set)
+//   - mints a JWT-shaped service-account token matching a configurable
+//     sub/namespace/serviceAccount, and writes it to a file
+//   - serves https on a configurable port
+//   - implements POST /apis/authentication.k8s.io/v1/tokenreviews returning a
+//     happy-path TokenReviewStatus when the submitted token matches the one
+//     this mock issued, and a not-authenticated response otherwise
+//
+// This mock is intentionally minimal: a single token, one configurable
+// audience, no rotation, no real client-cert validation. It exists so the
+// integration test in tests/integration/k8s can drive spire-identity-exchange
+// end-to-end without requiring kube-apiserver or envtest in CI.
+//
+// Usage:
+//
+//	go run ./examples/mock-k8s-api [flags]
+//
+// Then configure spire-identity-exchange with:
+//
+//	"k8sSAToken": {
+//	  "apiHost": "https://localhost:9998",
+//	  "audiences": ["spire-identity-exchange"],
+//	  "tls": { "caFile": "...", "certFile": "...", "keyFile": "..." }
+//	}
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+)
+
+const tokenReviewPath = "/apis/authentication.k8s.io/v1/tokenreviews"
+
+func main() {
+	port := flag.Int("port", 9998, "Port to serve TokenReview on (TLS)")
+	audience := flag.String("audience", "spire-identity-exchange", "Token audience and accepted TokenReview Spec.Audience")
+	namespace := flag.String("namespace", "default", "kubernetes.io.namespace claim")
+	serviceAccount := flag.String("service-account", "test-sa", "kubernetes.io.serviceaccount.name claim")
+	issuer := flag.String("issuer", "https://kubernetes.default.svc.cluster.local", "Token issuer (iss claim)")
+	ttl := flag.Duration("ttl", 10*time.Minute, "Token lifetime")
+	dir := flag.String("dir", ".", "Directory to write ca.pem, client.pem, client.key, server.pem, server.key, and token")
+	tokenFile := flag.String("token-file", "token", "Filename (under -dir) to write the SA token to")
+	flag.Parse()
+
+	if err := os.MkdirAll(*dir, 0o755); err != nil {
+		log.Fatalf("failed to create -dir %q: %v", *dir, err)
+	}
+
+	// CA + server cert: the validator needs CAFile to verify the mock's serving
+	// cert, so we self-sign a CA, then issue a server cert from it.
+	caCert, caKey, caPEM, err := newCA("mock-k8s-api-ca")
+	if err != nil {
+		log.Fatalf("failed to create CA: %v", err)
+	}
+	serverPEM, serverKeyPEM, err := newServerCert(caCert, caKey)
+	if err != nil {
+		log.Fatalf("failed to issue server cert: %v", err)
+	}
+
+	// Placeholder client cert: the mock does not verify mTLS, but the validator's
+	// client config requires CertFile + KeyFile to be set, so we hand it a
+	// self-signed throwaway pair.
+	clientPEM, clientKeyPEM, err := newSelfSignedClientCert("mock-k8s-api-client")
+	if err != nil {
+		log.Fatalf("failed to issue placeholder client cert: %v", err)
+	}
+
+	paths := map[string][]byte{
+		"ca.pem":     caPEM,
+		"server.pem": serverPEM,
+		"server.key": serverKeyPEM,
+		"client.pem": clientPEM,
+		"client.key": clientKeyPEM,
+	}
+	for name, data := range paths {
+		if err := os.WriteFile(filepath.Join(*dir, name), data, 0o600); err != nil {
+			log.Fatalf("failed to write %s: %v", name, err)
+		}
+	}
+
+	// Sign the SA-shaped token with an arbitrary RSA key. The validator does
+	// not verify signatures (it parses unverified and trusts TokenReview), but
+	// signing keeps the token structurally identical to a real projected SA token.
+	signingKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		log.Fatalf("failed to generate signing key: %v", err)
+	}
+
+	sub := fmt.Sprintf("system:serviceaccount:%s:%s", *namespace, *serviceAccount)
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"iss": *issuer,
+		"sub": sub,
+		"aud": jwt.ClaimStrings{*audience},
+		"iat": now.Unix(),
+		"nbf": now.Unix(),
+		"exp": now.Add(*ttl).Unix(),
+		"jti": uuid.New().String(),
+		"kubernetes.io": map[string]interface{}{
+			"namespace": *namespace,
+			"serviceaccount": map[string]interface{}{
+				"name": *serviceAccount,
+				"uid":  uuid.New().String(),
+			},
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = "mock-k8s-key-1"
+	signed, err := token.SignedString(signingKey)
+	if err != nil {
+		log.Fatalf("failed to sign SA token: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(*dir, *tokenFile), []byte(signed), 0o600); err != nil {
+		log.Fatalf("failed to write token: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(tokenReviewPath, tokenReviewHandler(signed, sub, *audience))
+
+	addr := fmt.Sprintf(":%d", *port)
+	server := &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+
+	fmt.Println("=== Mock K8s API server ===")
+	fmt.Printf("apiHost:           https://localhost:%d\n", *port)
+	fmt.Printf("Audience:          %s\n", *audience)
+	fmt.Printf("SA token sub:      %s\n", sub)
+	fmt.Printf("Token expiry:      %s\n", now.Add(*ttl).Format(time.RFC3339))
+	fmt.Printf("Materials in:      %s\n", *dir)
+	fmt.Printf("TokenReview path:  POST %s\n", tokenReviewPath)
+	fmt.Println()
+	fmt.Println("Configure spire-identity-exchange with:")
+	fmt.Printf(`  "k8sSAToken": {`+"\n")
+	fmt.Printf(`    "apiHost":   "https://localhost:%d",`+"\n", *port)
+	fmt.Printf(`    "audiences": ["%s"],`+"\n", *audience)
+	fmt.Printf(`    "tls": {`+"\n")
+	fmt.Printf(`      "caFile":   "%s/ca.pem",`+"\n", *dir)
+	fmt.Printf(`      "certFile": "%s/client.pem",`+"\n", *dir)
+	fmt.Printf(`      "keyFile":  "%s/client.key"`+"\n", *dir)
+	fmt.Printf(`    }`+"\n")
+	fmt.Printf(`  }`+"\n")
+	fmt.Println()
+
+	if err := server.ListenAndServeTLS(filepath.Join(*dir, "server.pem"), filepath.Join(*dir, "server.key")); err != nil {
+		log.Fatalf("server exited: %v", err)
+	}
+}
+
+// tokenReviewHandler returns a happy-path TokenReview response when the
+// submitted token matches the one this mock issued; otherwise it returns a
+// not-authenticated response. The handler echoes the requested audiences back
+// in Status.Audiences when they intersect with the configured audience, so
+// spire-identity-exchange's audience-binding check passes.
+func tokenReviewHandler(expectedToken, username, configuredAudience string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		var req struct {
+			Spec struct {
+				Token     string   `json:"token"`
+				Audiences []string `json:"audiences"`
+			} `json:"spec"`
+		}
+		if err := json.Unmarshal(body, &req); err != nil {
+			http.Error(w, "parse body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		resp := map[string]interface{}{
+			"kind":       "TokenReview",
+			"apiVersion": "authentication.k8s.io/v1",
+			"status": map[string]interface{}{
+				"authenticated": false,
+			},
+		}
+
+		if req.Spec.Token == expectedToken && intersect(req.Spec.Audiences, configuredAudience) {
+			resp["status"] = map[string]interface{}{
+				"authenticated": true,
+				"audiences":     []string{configuredAudience},
+				"user": map[string]interface{}{
+					"username": username,
+					"groups": []string{
+						"system:serviceaccounts",
+						"system:serviceaccounts:" + namespaceFromSub(username),
+						"system:authenticated",
+					},
+				},
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// intersect returns true when the empty allowlist case (no audience binding)
+// or when audiences contains configuredAudience.
+func intersect(audiences []string, configuredAudience string) bool {
+	if len(audiences) == 0 {
+		return true
+	}
+	for _, a := range audiences {
+		if a == configuredAudience {
+			return true
+		}
+	}
+	return false
+}
+
+// namespaceFromSub extracts the namespace from a "system:serviceaccount:ns:sa" sub.
+func namespaceFromSub(sub string) string {
+	const prefix = "system:serviceaccount:"
+	if len(sub) <= len(prefix) {
+		return ""
+	}
+	rest := sub[len(prefix):]
+	for i := 0; i < len(rest); i++ {
+		if rest[i] == ':' {
+			return rest[:i]
+		}
+	}
+	return rest
+}
+
+// newCA generates a self-signed CA cert + key and returns the cert in both
+// parsed and PEM forms (PEM for writing to disk, parsed for issuing leaf certs).
+func newCA(commonName string) (*x509.Certificate, *rsa.PrivateKey, []byte, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return cert, key, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), nil
+}
+
+// newServerCert issues a server cert signed by the given CA, valid for
+// localhost / 127.0.0.1 (sufficient for the integration test's single-host CI runner).
+func newServerCert(caCert *x509.Certificate, caKey *rsa.PrivateKey) ([]byte, []byte, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "mock-k8s-api"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), keyPEM, nil
+}
+
+// newSelfSignedClientCert generates a self-signed cert + key. The mock does
+// not verify client certs, but spire-identity-exchange's TokenReview config
+// requires CertFile/KeyFile to be set.
+func newSelfSignedClientCert(commonName string) ([]byte, []byte, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), keyPEM, nil
+}

--- a/tests/integration/k8s/default.json
+++ b/tests/integration/k8s/default.json
@@ -1,0 +1,49 @@
+{
+  "name": "spire-identity-exchange",
+  "logLevel": "info",
+  "server": {
+    "port": 8443,
+    "metricsPort": 4950,
+    "restPort": 8444,
+    "tls": {
+      "certFile": "/etc/spire/identity-exchange/${SYSTEMD_INSTANCE}/certs/server.pem",
+      "keyFile": "/etc/spire/identity-exchange/${SYSTEMD_INSTANCE}/certs/server.key"
+    }
+  },
+  "spire": {
+    "unixSocketPath": "/var/run/spire/server/sockets/${SYSTEMD_INSTANCE}/private/api.sock",
+    "agentWorkloadSocketPath": "/var/run/spire/agent/sockets/${SYSTEMD_INSTANCE}/public/api.sock",
+    "agentDelegatedSocketPath": "/var/run/spire/agent/sockets/six/private/admin.sock",
+    "trustDomain": "${SPIFFE_TRUST_DOMAIN}",
+    "svidTTL": "5m"
+  },
+  "auth": {
+    "plugins": [{
+      "name": "k8s",
+      "plugin": "k8s_sa_token",
+      "config": {
+        "apiHost": "https://localhost:9998",
+        "clusterName": "mock-cluster",
+        "audiences": ["spire-identity-exchange"],
+        "allowedNamespaces": ["default"],
+        "tls": {
+          "caFile":   "/etc/spire/identity-exchange/mock-k8s/ca.pem",
+          "certFile": "/etc/spire/identity-exchange/mock-k8s/client.pem",
+          "keyFile":  "/etc/spire/identity-exchange/mock-k8s/client.key"
+        }
+      }
+    }]
+  },
+  "k8sSAToken": {
+    "enabled": true,
+    "apiHost": "https://localhost:9998",
+    "clusterName": "mock-cluster",
+    "audiences": ["spire-identity-exchange"],
+    "spiffeIdTemplate": "spiffe://{{.trust_domain}}/spire-identity-exchange/k8s/{{.k8s_cluster_name}}/{{index . \"kubernetes.io\" \"namespace\"}}/{{index . \"kubernetes.io\" \"serviceaccount\" \"name\"}}",
+    "tls": {
+      "caFile":   "/etc/spire/identity-exchange/mock-k8s/ca.pem",
+      "certFile": "/etc/spire/identity-exchange/mock-k8s/client.pem",
+      "keyFile":  "/etc/spire/identity-exchange/mock-k8s/client.key"
+    }
+  }
+}

--- a/tests/integration/k8s/manifests/node1-service-spire-identity-exchange.yaml
+++ b/tests/integration/k8s/manifests/node1-service-spire-identity-exchange.yaml
@@ -1,0 +1,9 @@
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterStaticEntry
+metadata:
+  name: node1-service-spire-identity-exchange
+spec:
+  parentID: spiffe://${SPIFFE_TRUST_DOMAIN}/agent/node1
+  spiffeID: spiffe://${SPIFFE_TRUST_DOMAIN}/service/spire-identity-exchange
+  selectors:
+  - systemd:id:spire-identity-exchange@main.service

--- a/tests/integration/k8s/manifests/node1-six-nodealias.yaml
+++ b/tests/integration/k8s/manifests/node1-six-nodealias.yaml
@@ -1,0 +1,10 @@
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterStaticEntry
+metadata:
+  name: node1-six-nodealias
+spec:
+  parentID: spiffe://${SPIFFE_TRUST_DOMAIN}/spire/server
+  spiffeID: spiffe://${SPIFFE_TRUST_DOMAIN}/spire-identity-exchange
+  selectors:
+    - spiffe_id:spiffe://${SPIFFE_TRUST_DOMAIN}/spire/agent/x509pop/spire-identity-exchange/node1
+

--- a/tests/integration/k8s/manifests/node1-spire-agent-six.yaml
+++ b/tests/integration/k8s/manifests/node1-spire-agent-six.yaml
@@ -1,0 +1,9 @@
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterStaticEntry
+metadata:
+  name: node1-spire-agent-six
+spec:
+  parentID: spiffe://${SPIFFE_TRUST_DOMAIN}/agent/node1
+  spiffeID: spiffe://${SPIFFE_TRUST_DOMAIN}/spire-exchange/spire-identity-exchange/node1
+  selectors:
+  - systemd:id:spire-agent@six.service

--- a/tests/integration/k8s/manifests/six-k8s-job.yaml
+++ b/tests/integration/k8s/manifests/six-k8s-job.yaml
@@ -1,0 +1,10 @@
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterStaticEntry
+metadata:
+  name: six-k8s-test
+spec:
+  parentID: spiffe://${SPIFFE_TRUST_DOMAIN}/spire-identity-exchange
+  spiffeID: spiffe://${SPIFFE_TRUST_DOMAIN}/k8s/test
+  selectors:
+  - k8s_sa_token:namespace:default
+  - k8s_sa_token:service_account_name:test-sa

--- a/tests/integration/k8s/manifests/six-service-spire-identity-exchange.yaml
+++ b/tests/integration/k8s/manifests/six-service-spire-identity-exchange.yaml
@@ -1,0 +1,10 @@
+# Needed only for the delegated api. The broker api will not need this and should be removed once the delegated api is removed.
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterStaticEntry
+metadata:
+  name: six-service-spire-identity-exchange
+spec:
+  parentID: spiffe://${SPIFFE_TRUST_DOMAIN}/spire-identity-exchange
+  spiffeID: spiffe://${SPIFFE_TRUST_DOMAIN}/service/spire-identity-exchange
+  selectors:
+  - systemd:id:spire-identity-exchange@main.service

--- a/tests/integration/k8s/run-tests.sh
+++ b/tests/integration/k8s/run-tests.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2317
+
+set -xeo pipefail
+
+SCRIPT="$(readlink -f "$0")"
+SCRIPTPATH="$(dirname "${SCRIPT}")"
+
+if [ "x${GITHUB_JOB}" != "x" ]; then
+  echo "Running in GitHub"
+else
+  echo "Do not run this script on your own box. For testing, it deploys a testing local spire ha setup using sudo. This is likely not what you want. Only use this script as a reference."
+  exit 1
+fi
+
+teardown() {
+  echo ---------------------------
+  echo "::group::Status Output"
+  sudo systemctl status spire-identity-exchange@main.service -n 50 2>&1 || true
+  sudo systemctl status spire-server@main 2>&1 || true
+  sudo spire-server entry show 2>&1 || true
+  sudo systemctl status spire-controller-manager@main 2>&1 || true
+  sudo systemctl status spire-agent@main 2>&1 || true
+  sudo systemctl status spire-agent@six 2>&1 || true
+}
+
+trap 'EC=$? && trap - SIGTERM && teardown $EC' SIGINT SIGTERM EXIT
+
+wait_for_healthcheck() {
+  local app="$1"
+  local socket="$2"
+  local timeout=30
+  local count=0
+  while [ "$count" -lt "$timeout" ]; do
+    rc=0
+    sudo "$app" healthcheck -socketPath "$socket" || rc=$?
+    if [ "$rc" -eq 0 ]; then
+      return 0
+    fi
+    sleep 1
+    ((count++)) || true
+  done
+  return 1
+}
+
+# Setup mock k8s api server. Consider moving this out to a systemd service.
+MOCK_DIR="$(pwd)/mock-k8s-materials"
+rm -rf "${MOCK_DIR}" && mkdir -p "${MOCK_DIR}"
+go build -o mock-k8s-api ${SCRIPTPATH}/../../../examples/mock-k8s-api/main.go
+./mock-k8s-api -dir "${MOCK_DIR}" -port 9998 &
+MAX_WAIT=30
+ELAPSED=0
+while true; do
+  if [ -f "${MOCK_DIR}/token" ] && [ -f "${MOCK_DIR}/ca.pem" ]; then
+    break
+  fi
+  if [ $ELAPSED -ge $MAX_WAIT ]; then
+    echo "Timed out waiting for mock-k8s-api to write materials."
+    exit 1
+  fi
+  sleep 1
+  ((ELAPSED++)) || true
+done
+export K8S_SA_TOKEN="$(cat "${MOCK_DIR}/token")"
+echo "::add-mask::${K8S_SA_TOKEN}"
+set -x
+
+# spire-identity-exchange's k8s validator reads CA/client cert from a fixed path
+# in /etc/spire/identity-exchange/mock-k8s/ (referenced by default.json).
+sudo mkdir -p /etc/spire/identity-exchange/mock-k8s
+sudo cp "${MOCK_DIR}/ca.pem" "${MOCK_DIR}/client.pem" "${MOCK_DIR}/client.key" /etc/spire/identity-exchange/mock-k8s/
+
+# Get the package repo and install the packages.
+sudo curl -s -o /etc/apt/sources.list.d/spire-examples.list https://raw.githubusercontent.com/spiffe/spire-examples/refs/heads/main/examples/debs/amd64/spire-examples.list
+sudo apt-get update
+sudo apt-get install -y spire-common spire-agent spire-server spire-controller-manager
+
+# Register some workloads with the spire server using manifests.
+sudo mkdir -p /etc/spire/server/main/manifests/
+sudo cp "${SCRIPTPATH}/manifests"/* /etc/spire/server/main/manifests/
+
+# Startup server and make sure its ready.
+sudo cp "${SCRIPTPATH}/server.conf" /etc/spire/server/main.conf
+sudo systemctl start spire-server@main spire-controller-manager@main
+wait_for_healthcheck spire-server /run/spire/server/sockets/main/private/api.sock
+
+# Configure agents.
+JOIN_TOKEN=$(sudo spire-server token generate -spiffeID spiffe://example.org/agent/node1 | awk '{print "\""$2"\""}')
+export JOIN_TOKEN
+sudo /bin/bash -c "echo JOIN_TOKEN=${JOIN_TOKEN} > /etc/spire/agent/main.env"
+sudo cp "${SCRIPTPATH}/six-agent.conf" /etc/spire/agent/six.conf
+
+# Startup agents.
+sudo systemctl start spire-agent@main spire-agent@six
+wait_for_healthcheck spire-agent /var/run/spire/agent/sockets/main/public/api.sock
+wait_for_healthcheck spire-agent /var/run/spire/agent/sockets/six/public/api.sock
+
+make build
+
+sudo mkdir -p /usr/libexec/spire/
+sudo cp -a build/bin/spire-identity-exchange /usr/libexec/spire/
+
+sudo mkdir -p /etc/spire/identity-exchange/main/certs
+sudo openssl req -x509 -newkey rsa:2048 \
+  -keyout /etc/spire/identity-exchange/main/certs/server.key \
+  -out /etc/spire/identity-exchange/main/certs/server.pem -sha256 -days 365 -nodes \
+  -subj "/CN=localhost" \
+  -addext "basicConstraints=critical,CA:TRUE" \
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+
+sudo cp "${SCRIPTPATH}/default.json" /etc/spire/identity-exchange/
+sudo cp "${SCRIPTPATH}/../../../systemd/spire-identity-exchange@.service" /etc/systemd/system
+sudo systemctl daemon-reload
+sudo systemctl start spire-identity-exchange@main.service
+
+MAX_WAIT=30
+ELAPSED=0
+while true; do
+  if curl -s -o /dev/null https://localhost:8443 -k; then
+    break
+  fi
+  if [ $ELAPSED -ge $MAX_WAIT ]; then
+    echo "Timed out waiting for spire-identity-exchange."
+    exit 1
+  fi
+  sleep 1
+  ((ELAPSED++)) || true
+done
+
+go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
+
+# gRPC path: MintCertificateByK8sSAToken via the legacy k8sSAToken block.
+# Uses server-side key generation so we don't need a CSR.
+~/go/bin/grpcurl -cacert /etc/spire/identity-exchange/main/certs/server.pem \
+  -d "{\"k8sSA\":{\"k8sSAToken\":\"${K8S_SA_TOKEN}\"},\"mintJWTSVIDRequest\":{\"audiences\":[\"foo\"]}}" \
+  localhost:8443 \
+  proto.spiffe.spireidentityexchange.SpireIdentityExchangeApi/MintCertificate
+
+# REST path: POST /api/v1/svid/k8s/x509 — uses cfg.Auth.Plugins → pkg/validator/k8s
+# via the delegated identity API. The plugin instance is named "k8s" in default.json.
+curl -H "Authorization: Bearer ${K8S_SA_TOKEN}" -X POST https://localhost:8444/api/v1/svid/k8s/x509 --cacert /etc/spire/identity-exchange/main/certs/server.pem -sS

--- a/tests/integration/k8s/server.conf
+++ b/tests/integration/k8s/server.conf
@@ -1,0 +1,39 @@
+server {
+    bind_address = "${SPIRE_BIND_ADDRESS}"
+    bind_port = "${SPIRE_BIND_PORT}"
+    trust_domain = "${SPIFFE_TRUST_DOMAIN}"
+    jwt_issuer = "https://oidc-discovery-provider.${SPIFFE_TRUST_DOMAIN}"
+    log_level = "${SPIRE_LOG_LEVEL}"
+    ca_ttl = "168h"
+    default_x509_svid_ttl = "48h"
+    experimental {
+        agent_spiffe_id_as_selector = true
+    }
+}
+
+plugins {
+    DataStore "sql" {
+        plugin_data {
+            database_type = "sqlite3"
+            connection_string = "./datastore.sqlite3"
+        }
+    }
+
+    KeyManager "disk" {
+        plugin_data {
+            keys_path = "./keys.json"
+        }
+    }
+
+    NodeAttestor "join_token" {
+        plugin_data {}
+    }
+
+    NodeAttestor "x509pop" {
+        plugin_data {
+            mode = "spiffe"
+            spiffe_prefix	= "/spire-exchange/spire-identity-exchange/"
+            agent_path_template = "/{{ .PluginName }}/spire-identity-exchange/{{ .SVIDPathTrimmed }}"
+        }
+    }
+}

--- a/tests/integration/k8s/six-agent.conf
+++ b/tests/integration/k8s/six-agent.conf
@@ -1,0 +1,31 @@
+agent {
+    log_level = "DEBUG"
+    trust_domain = "${SPIFFE_TRUST_DOMAIN}"
+    server_address = "localhost"
+    server_port = ${SPIRE_SERVER_PORT}
+
+    # Insecure bootstrap is NOT appropriate for production use but is ok for
+    # simple testing/evaluation purposes.
+    insecure_bootstrap = true
+
+    admin_socket_path = "${SPIRE_AGENT_ADMIN_ADDRESS}"
+    authorized_delegates = ["spiffe://${SPIFFE_TRUST_DOMAIN}/service/spire-identity-exchange"]
+}
+
+plugins {
+   KeyManager "disk" {
+        plugin_data {
+            directory = "./"
+        }
+    }
+
+    NodeAttestor "x509pop" {
+        plugin_data {
+            spiffe_endpoint_socket = "unix:///var/run/spire/agent/sockets/main/public/api.sock"
+        }
+    }
+
+    WorkloadAttestor "systemd" {
+        plugin_data {}
+    }
+}


### PR DESCRIPTION
> **Depends on #43.** This PR's `tests/integration/k8s/default.json` references the `k8s_sa_token` plugin type that #43 adds to `pkg/validator/registry`. Until #43 merges, the spire-identity-exchange service will refuse to start under this test config (`plugin type "k8s_sa_token" is unknown`) and the integration CI job will fail. After #43 merges, a rebase pulls in the registry entry — the diff in this PR does not change.

## Summary

Mirrors the `mock-github-oidc` / `tests/integration/github` pattern so the K8s SA token validator can be driven end-to-end in CI without standing up kube-apiserver, envtest, or kind.

## What's added

### `examples/mock-k8s-api/main.go`

A Go binary that on startup:
- Generates a self-signed CA + server TLS cert pair, writes both to `-dir`.
- Generates a placeholder client cert + key. The mock does not actually verify mTLS, but `pkg/validator/k8s.TLSConfig` requires `CertFile`/`KeyFile` to be set; this gives the validator something benign to present.
- Mints a JWT-shaped projected SA token with configurable `-namespace`, `-service-account`, `-audience`, `-issuer`, `-ttl`. Token is signed with an arbitrary RSA key — the validator parses unverified and trusts TokenReview, so the signature isn't load-bearing; signing keeps the wire shape identical to a real projected SA token.
- Serves HTTPS on `-port` and implements `POST /apis/authentication.k8s.io/v1/tokenreviews`. Returns a happy-path `TokenReviewStatus{Authenticated: true, User.Username: <sub>, Audiences: [<audience>]}` when the submitted token matches the one this mock issued **and** the requested audiences intersect with the configured audience. Otherwise returns `Authenticated: false`.

Intentionally minimal: single token, single audience, no real client-cert verification. Failure-mode fidelity (audience mismatch, non-SA principal, TokenReview rejection) is covered exhaustively by unit tests in `pkg/validator/k8s/tokenreview_test.go` from #43.

### `tests/integration/k8s/`

SPIRE stack config + `run-tests.sh` modeled on `tests/integration/github`. Drives `spire-identity-exchange` against the mock through both validator paths:

| Path | Endpoint | Validator |
|---|---|---|
| gRPC `MintCertificateByK8sSAToken` | `proto.spiffe.spireidentityexchange.SpireIdentityExchangeApi/MintCertificate` | `internal/k8s-sa-token.Validator` (legacy `cfg.K8sSAToken` block) |
| REST `POST /api/v1/svid/k8s/x509` | gateway → delegated-identity mint | `pkg/validator/k8s.Validator` (loaded from `cfg.Auth.Plugins`) |

The REST path's registration entry (`tests/integration/k8s/manifests/six-k8s-job.yaml`) selects on `k8s_sa_token:namespace:default` + `k8s_sa_token:service_account_name:test-sa` — the selectors emitted by `pkg/validator/k8s.GenerateSelectors` for the mock-issued token.

`.github/workflows/test.yaml` auto-discovers integration tests via `find tests/integration -maxdepth 2 -type f -name run-tests.sh` — no workflow edit needed.

## Out of scope

- **Failure-mode integration coverage.** Single happy-path token; rejection paths stay in unit tests where they're cheap to exercise.
- **Real K8s API server.** If higher fidelity is wanted later (real projected SA tokens, real `kube-apiserver` audience binding), envtest or kind would be a separate PR — different cost/CI footprint.
- **Allowlist negative cases in the integration test.** `pkg/validator/k8s.checkAllowLists` is unit-tested in #43.

## Test plan

- [x] `go build ./...`
- [x] `bash -n tests/integration/k8s/run-tests.sh` (syntax)
- [x] Local smoke test of the mock: brought it up, hit `POST /apis/authentication.k8s.io/v1/tokenreviews` with the issued token (returns `authenticated: true`), then with a junk token (returns `authenticated: false`).
- [ ] CI integration job — **will fail until #43 merges; rebase will fix.**