### PR TITLE
Add optional JWKS check stage before TokenReview in k8s SA token vali…

### DIFF
--- a/pkg/validator/jwt/keyprovider.go
+++ b/pkg/validator/jwt/keyprovider.go
@@ -33,6 +33,12 @@ type DefaultKeyProvider struct {
 	httpClient *http.Client
 	metrics    validator.Metrics
 
+	// jwksURIOverride, when set, is used as the JWKS URL directly and OIDC
+	// discovery is skipped. Used by callers that already know the JWKS URI
+	// (e.g. a K8s validator that learns it from the API server) and may need
+	// to supply an authenticated httpClient to reach it.
+	jwksURIOverride string
+
 	mu    sync.RWMutex
 	cache *jwksCache
 }
@@ -50,6 +56,19 @@ func NewDefaultKeyProvider(issuerURL string, httpClient *http.Client, metrics va
 		issuerURL:  issuerURL,
 		httpClient: httpClient,
 		metrics:    metrics,
+	}
+}
+
+// NewKeyProviderWithJWKSURI creates a KeyProvider that fetches JWKS directly
+// from a known jwks_uri, skipping OIDC discovery. The caller supplies the
+// httpClient, which may be authenticated (e.g. a Kubernetes API server client)
+// when the JWKS endpoint requires authentication. Keys are cached and refetched
+// on cache miss or expiry, so brief endpoint downtime is tolerated.
+func NewKeyProviderWithJWKSURI(jwksURI string, httpClient *http.Client, metrics validator.Metrics) *DefaultKeyProvider {
+	return &DefaultKeyProvider{
+		jwksURIOverride: jwksURI,
+		httpClient:      httpClient,
+		metrics:         metrics,
 	}
 }
 
@@ -74,9 +93,10 @@ func (p *DefaultKeyProvider) GetKey(ctx context.Context, kid string) (crypto.Pub
 		}
 	}
 
-	// Reuse cached jwks_uri if available, otherwise discover it.
-	jwksURL := ""
-	if p.cache != nil {
+	// Resolve the JWKS URL: an explicit override wins, then a cached value,
+	// otherwise discover it via the issuer's OIDC discovery document.
+	jwksURL := p.jwksURIOverride
+	if jwksURL == "" && p.cache != nil {
 		jwksURL = p.cache.jwksURI
 	}
 	if jwksURL == "" {

--- a/pkg/validator/jwt/keyprovider.go
+++ b/pkg/validator/jwt/keyprovider.go
@@ -100,6 +100,9 @@ func (p *DefaultKeyProvider) GetKey(ctx context.Context, kid string) (crypto.Pub
 		jwksURL = p.cache.jwksURI
 	}
 	if jwksURL == "" {
+		if p.issuerURL == "" {
+			return nil, fmt.Errorf("no JWKS URI available: set a jwksURIOverride or an issuerURL for OIDC discovery")
+		}
 		var err error
 		jwksURL, err = p.discoverJWKSURI(ctx)
 		if err != nil {

--- a/pkg/validator/jwt/keyprovider_test.go
+++ b/pkg/validator/jwt/keyprovider_test.go
@@ -79,6 +79,45 @@ func TestGetKey(t *testing.T) {
 	})
 }
 
+func TestNewKeyProviderWithJWKSURI(t *testing.T) {
+	rsaKey := createTestRSAKey(t)
+	kid := "override-kid"
+
+	var jwksHits, discoveryHits atomic.Int64
+	mux := http.NewServeMux()
+	mux.HandleFunc("/openid/v1/jwks", func(w http.ResponseWriter, r *http.Request) {
+		jwksHits.Add(1)
+		jwk := jose.JSONWebKey{Key: &rsaKey.PublicKey, KeyID: kid, Algorithm: "RS256", Use: "sig"}
+		jwks := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk}}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(jwks)
+	})
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		discoveryHits.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	provider := NewKeyProviderWithJWKSURI(server.URL+"/openid/v1/jwks", server.Client(), nil)
+	ctx := context.Background()
+
+	t.Run("fetches_from_override_without_discovery", func(t *testing.T) {
+		key, err := provider.GetKey(ctx, kid)
+		require.NoError(t, err)
+		assert.IsType(t, &rsa.PublicKey{}, key)
+		assert.Equal(t, int64(1), jwksHits.Load())
+		assert.Equal(t, int64(0), discoveryHits.Load(), "override must skip OIDC discovery")
+	})
+
+	t.Run("cache_hit_skips_refetch", func(t *testing.T) {
+		jwksHits.Store(0)
+		_, err := provider.GetKey(ctx, kid)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), jwksHits.Load())
+	})
+}
+
 func TestFetchJWKS(t *testing.T) {
 	t.Run("valid_rsa_key", func(t *testing.T) {
 		rsaKey := createTestRSAKey(t)

--- a/pkg/validator/k8s/jwks.go
+++ b/pkg/validator/k8s/jwks.go
@@ -1,0 +1,105 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spiffe/spire-identity-exchange/pkg/validator"
+	"github.com/spiffe/spire-identity-exchange/pkg/validator/jwt"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	oidcDiscoveryPath = "/.well-known/openid-configuration"
+	jwksPath          = "/openid/v1/jwks"
+	discoveryTimeout  = 10 * time.Second
+	maxDiscoveryBytes = 1 << 20 // 1 MiB
+)
+
+type oidcDiscoveryDoc struct {
+	Issuer string `json:"issuer"`
+}
+
+// newJWKSCheckValidator builds the JWKS signature check stage. It reuses
+// the same credentials as TokenReview (in-cluster SA token or kubeconfig) to
+// reach the API server, discovers the cluster's token issuer, and verifies
+// token signatures against the API server's JWKS endpoint via the generic
+// jwt.Validator. Keys are cached, so an obviously-invalid token is rejected
+// without a TokenReview round-trip and brief API server downtime is tolerated
+// for already-cached keys.
+//
+// Only the self-hosted issuer case is supported: keys are fetched from the API
+// server's own /openid/v1/jwks endpoint with the authenticated client, so
+// credentials never leave the API server host. External-issuer setups (keys
+// served off-cluster) would need an explicit unauthenticated jwksUri, which is
+// not yet implemented.
+func newJWKSCheckValidator(cfg Config) (validator.TokenValidator, error) {
+	restCfg, err := getKubernetesConfig(cfg.Kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build kubernetes client config: %w", err)
+	}
+	httpClient, err := rest.HTTPClientFor(restCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build authenticated http client: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), discoveryTimeout)
+	defer cancel()
+	issuer, err := discoverClusterIssuer(ctx, httpClient, restCfg.Host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover cluster issuer: %w", err)
+	}
+
+	// Fetch keys from the API server's own JWKS endpoint with the authenticated
+	// client rather than the discovered jwks_uri, so the API server credentials
+	// and CA are never sent to a different host.
+	jwksURL := strings.TrimRight(restCfg.Host, "/") + jwksPath
+	keyProvider := jwt.NewKeyProviderWithJWKSURI(jwksURL, httpClient, cfg.Metrics)
+
+	return jwt.NewValidator(jwt.Config{
+		IssuerURL:   issuer,
+		Audiences:   cfg.Audiences,
+		KeyProvider: keyProvider,
+		Metrics:     cfg.Metrics,
+	})
+}
+
+// discoverClusterIssuer fetches the API server's OpenID Connect discovery
+// document and returns the issuer that signs service-account tokens. The
+// authenticated client is required because the discovery endpoint is not
+// exposed anonymously on most clusters.
+func discoverClusterIssuer(ctx context.Context, httpClient *http.Client, apiServerHost string) (string, error) {
+	configURL := strings.TrimRight(apiServerHost, "/") + oidcDiscoveryPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, configURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create discovery request: %w", err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch discovery document: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxDiscoveryBytes))
+	if err != nil {
+		return "", fmt.Errorf("failed to read discovery document: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP %d fetching discovery document: %s", resp.StatusCode, string(body))
+	}
+
+	var doc oidcDiscoveryDoc
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return "", fmt.Errorf("failed to parse discovery document: %w", err)
+	}
+	if doc.Issuer == "" {
+		return "", fmt.Errorf("discovery document missing issuer")
+	}
+	return doc.Issuer, nil
+}

--- a/pkg/validator/k8s/jwks_test.go
+++ b/pkg/validator/k8s/jwks_test.go
@@ -1,0 +1,67 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverClusterIssuer(t *testing.T) {
+	t.Run("valid_issuer", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, oidcDiscoveryPath, r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{
+				"issuer": "https://kubernetes.default.svc",
+			})
+		}))
+		defer server.Close()
+
+		issuer, err := discoverClusterIssuer(context.Background(), server.Client(), server.URL)
+		require.NoError(t, err)
+		assert.Equal(t, "https://kubernetes.default.svc", issuer)
+	})
+
+	t.Run("non_200_response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte("forbidden"))
+		}))
+		defer server.Close()
+
+		_, err := discoverClusterIssuer(context.Background(), server.Client(), server.URL)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "HTTP 403")
+	})
+
+	t.Run("invalid_json", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte("not json"))
+		}))
+		defer server.Close()
+
+		_, err := discoverClusterIssuer(context.Background(), server.Client(), server.URL)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse discovery document")
+	})
+
+	t.Run("missing_issuer", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{
+				"jwks_uri": "https://example.com/jwks",
+			})
+		}))
+		defer server.Close()
+
+		_, err := discoverClusterIssuer(context.Background(), server.Client(), server.URL)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing issuer")
+	})
+}

--- a/pkg/validator/k8s/validator.go
+++ b/pkg/validator/k8s/validator.go
@@ -66,28 +66,32 @@ type Config struct {
 	// would otherwise be apiHost + caFile + certFile + keyFile.
 	Kubeconfig string `json:"kubeconfig"`
 
-	// JWKSCheck enables a JWKS signature check. When enabled, a token whose
-	// signature, issuer, audience, or expiration fails verification against the
-	// cluster JWKS is rejected. JWKS check gates on cryptographic validity; it is
-	// cheap because keys are fetched periodically and cached, then verification
-	// runs in-process. The signing keys and issuer are discovered from the API
-	// server using the same credentials as TokenReview. Requires audiences to be set.
+	// JWKSCheck enables the in-process JWKS signature check. When enabled, a
+	// token whose signature, issuer, audience, or expiration fails verification
+	// against the cluster JWKS is rejected. The check is cheap: keys are fetched
+	// periodically and cached, then verification runs in-process. The signing
+	// keys and issuer are discovered from the API server using the same
+	// credentials as TokenReview. Requires audiences to be set.
 	//
-	// JWKSCheck and TokenReview are independent stages. At least one must be
-	// active: JWKSCheck defaults off, TokenReview defaults on (see
-	// DisableTokenReview), so the zero value runs TokenReview alone.
-	JWKSCheck bool `json:"jwksCheck"`
+	// It defaults to on (a nil pointer means enabled). Defaulting on protects the
+	// Kubernetes API server: a flood of bogus tokens is rejected in-process
+	// before any TokenReview round-trip, so the service does not amplify a denial
+	// of service onto the API server. Operators who understand the trade-off can
+	// disable it by setting it to false.
+	//
+	// JWKSCheck and TokenReview are independent stages; at least one must be on.
+	JWKSCheck *bool `json:"jwksCheck"`
 
-	// DisableTokenReview turns off the authoritative TokenReview stage. By
-	// default TokenReview runs (the zero value keeps it on). TokenReview is the
-	// heavier check because it round-trips to the API server for every token, so
-	// an operator may disable it and rely on the in-process JWKS check alone
-	// (e.g. for throughput or to tolerate brief API server downtime). When
-	// disabled, JWKSCheck must be enabled, because at least one validation stage
-	// must remain active. Note the trade-off: TokenReview is what validates the
-	// token against the cluster's live state, so relying on JWKS alone gives up
-	// that check.
-	DisableTokenReview bool `json:"disableTokenReview"`
+	// TokenReview enables the authoritative TokenReview stage, which round-trips
+	// to the API server for every token and validates it against the cluster's
+	// live state.
+	//
+	// It defaults to on (a nil pointer means enabled). An operator may set it to
+	// false to rely on the in-process JWKS check alone (e.g. for throughput or to
+	// tolerate brief API server downtime), in which case JWKSCheck must be on,
+	// because at least one validation stage must remain active. Relying on JWKS
+	// alone gives up the live-state check.
+	TokenReview *bool `json:"tokenReview"`
 
 	// AuthClient overrides the default-built TokenReview client. Primarily a
 	// test seam — passed through to the inner TokenReviewValidator. Mirrors how
@@ -96,7 +100,7 @@ type Config struct {
 	AuthClient authenticationv1.AuthenticationV1Interface `json:"-"`
 
 	// jwksValidator overrides the JWKS check stage. Test seam, mirrors
-	// AuthClient. When nil and JWKSCheck is true, NewValidator builds one
+	// AuthClient. When nil and the JWKS check is enabled, NewValidator builds one
 	// from the API server's discovered OIDC configuration.
 	jwksValidator validator.TokenValidator
 
@@ -109,6 +113,16 @@ func (c *Config) Unmarshal(raw json.RawMessage) error {
 	return json.Unmarshal(raw, c)
 }
 
+// enabled resolves an optional on/off flag: a nil pointer takes the default,
+// otherwise the explicit value wins. Used so JWKSCheck and TokenReview can
+// distinguish "unset" (apply default) from an explicit false.
+func enabled(p *bool, def bool) bool {
+	if p == nil {
+		return def
+	}
+	return *p
+}
+
 func (c *Config) ValidateConfig() error {
 	var errs []error
 
@@ -116,16 +130,21 @@ func (c *Config) ValidateConfig() error {
 		errs = append(errs, errors.New("at least one of allowedNamespaces or allowedServiceAccounts must be specified"))
 	}
 
-	// The JWKS check verifies the token audience against the configured
-	// list, so it cannot run without one.
-	if c.JWKSCheck && len(c.Audiences) == 0 {
-		errs = append(errs, errors.New("audiences is required when jwksCheck is enabled"))
+	jwksOn := enabled(c.JWKSCheck, true)
+	tokenReviewOn := enabled(c.TokenReview, true)
+
+	// At least one validation stage must remain active; otherwise the validator
+	// would accept every token. Both default on, so this requires explicitly
+	// disabling both.
+	if !jwksOn && !tokenReviewOn {
+		errs = append(errs, errors.New("at least one of jwksCheck or tokenReview must be enabled"))
 	}
 
-	// At least one validation stage must remain active. TokenReview defaults on,
-	// so the only way to end up with neither is disabling it without jwksCheck.
-	if c.DisableTokenReview && !c.JWKSCheck {
-		errs = append(errs, errors.New("jwksCheck is required when disableTokenReview is set"))
+	// The JWKS check verifies the token audience against the configured list, so
+	// it cannot run without one. Because it defaults on, audiences is effectively
+	// required unless jwksCheck is explicitly disabled.
+	if jwksOn && len(c.Audiences) == 0 {
+		errs = append(errs, errors.New("audiences is required when jwksCheck is enabled"))
 	}
 
 	// API server connectivity comes from the kubeconfig / in-cluster fallback,
@@ -150,9 +169,9 @@ func (c *Config) NewValidator() (validator.TokenValidatorAndSelectorGenerator, e
 // Mirrors how pkg/validator/github.Validator wraps pkg/validator/jwt.Validator.
 type Validator struct {
 	// jwksCheck and inner are independent validation stages; at least one is
-	// non-nil. jwksCheck is the optional in-process JWKS signature check; inner
-	// is the authoritative TokenReview stage, nil when DisableTokenReview is set.
-	// When both run, JWKS runs first and TokenReview's claims are authoritative.
+	// non-nil. jwksCheck is the in-process JWKS signature check; inner is the
+	// authoritative TokenReview stage, nil when TokenReview is disabled. When
+	// both run, JWKS runs first and TokenReview's claims are authoritative.
 	jwksCheck              validator.TokenValidator
 	inner                  *TokenReviewValidator
 	clusterName            string
@@ -172,11 +191,14 @@ func NewValidator(cfg Config) (*Validator, error) {
 		return nil, fmt.Errorf("at least one of allowedNamespaces or allowedServiceAccounts must be specified")
 	}
 
-	// Build the optional JWKS check stage. The injected jwksValidator wins
+	jwksOn := enabled(cfg.JWKSCheck, true)
+	tokenReviewOn := enabled(cfg.TokenReview, true)
+
+	// Build the JWKS check stage when enabled. The injected jwksValidator wins
 	// (test seam); otherwise it is built from the API server's discovered OIDC
-	// configuration when JWKSCheck is enabled.
+	// configuration.
 	jwksCheck := cfg.jwksValidator
-	if jwksCheck == nil && cfg.JWKSCheck {
+	if jwksCheck == nil && jwksOn {
 		if len(cfg.Audiences) == 0 {
 			return nil, fmt.Errorf("audiences is required when jwksCheck is enabled")
 		}
@@ -187,10 +209,10 @@ func NewValidator(cfg Config) (*Validator, error) {
 		}
 	}
 
-	// Build the authoritative TokenReview stage unless disabled. When disabled,
-	// jwksCheck must exist so the Validator is not a no-op that accepts every token.
+	// Build the authoritative TokenReview stage when enabled. When off, jwksCheck
+	// must exist so the Validator is not a no-op that accepts every token.
 	var inner *TokenReviewValidator
-	if !cfg.DisableTokenReview {
+	if tokenReviewOn {
 		var err error
 		inner, err = NewTokenReviewValidator(TokenReviewConfig{
 			Audiences:  cfg.Audiences,
@@ -203,7 +225,7 @@ func NewValidator(cfg Config) (*Validator, error) {
 	}
 
 	if inner == nil && jwksCheck == nil {
-		return nil, fmt.Errorf("jwksCheck is required when disableTokenReview is set")
+		return nil, fmt.Errorf("at least one of jwksCheck or tokenReview must be enabled")
 	}
 
 	return &Validator{

--- a/pkg/validator/k8s/validator.go
+++ b/pkg/validator/k8s/validator.go
@@ -166,6 +166,9 @@ func NewValidator(cfg Config) (*Validator, error) {
 	// configuration when JWKSCheck is enabled.
 	jwksCheck := cfg.jwksValidator
 	if jwksCheck == nil && cfg.JWKSCheck {
+		if len(cfg.Audiences) == 0 {
+			return nil, fmt.Errorf("audiences is required when jwksCheck is enabled")
+		}
 		jwksCheck, err = newJWKSCheckValidator(cfg)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create JWKS check validator: %w", err)

--- a/pkg/validator/k8s/validator.go
+++ b/pkg/validator/k8s/validator.go
@@ -66,11 +66,26 @@ type Config struct {
 	// would otherwise be apiHost + caFile + certFile + keyFile.
 	Kubeconfig string `json:"kubeconfig"`
 
+	// JWKSCheck enables a JWKS signature check before TokenReview. When
+	// enabled, a token whose signature, issuer, audience, or expiration fails
+	// verification against the cluster JWKS is rejected without a TokenReview
+	// round-trip to the API server. JWKS check gates on cryptographic validity;
+	// TokenReview additionally validates the token against the cluster's live state.
+	// The signing keys and
+	// issuer are discovered from the API server using the same credentials as
+	// TokenReview and cached. Requires audiences to be set.
+	JWKSCheck bool `json:"jwksCheck"`
+
 	// AuthClient overrides the default-built TokenReview client. Primarily a
 	// test seam — passed through to the inner TokenReviewValidator. Mirrors how
 	// pkg/validator/github.Config carries KeyProvider through to the inner
 	// pkg/validator/jwt.Validator.
 	AuthClient authenticationv1.AuthenticationV1Interface `json:"-"`
+
+	// jwksValidator overrides the JWKS check stage. Test seam, mirrors
+	// AuthClient. When nil and JWKSCheck is true, NewValidator builds one
+	// from the API server's discovered OIDC configuration.
+	jwksValidator validator.TokenValidator
 
 	// Metrics allows injecting a metrics collector for operation tracking.
 	// If nil, metrics collection is silently skipped.
@@ -86,6 +101,12 @@ func (c *Config) ValidateConfig() error {
 
 	if len(c.AllowedNamespaces) == 0 && len(c.AllowedServiceAccounts) == 0 {
 		errs = append(errs, errors.New("at least one of allowedNamespaces or allowedServiceAccounts must be specified"))
+	}
+
+	// The JWKS check verifies the token audience against the configured
+	// list, so it cannot run without one.
+	if c.JWKSCheck && len(c.Audiences) == 0 {
+		errs = append(errs, errors.New("audiences is required when jwksCheck is enabled"))
 	}
 
 	// API server connectivity comes from the kubeconfig / in-cluster fallback,
@@ -109,6 +130,10 @@ func (c *Config) NewValidator() (validator.TokenValidatorAndSelectorGenerator, e
 // injection into the claim map and namespace / service-account allowlists.
 // Mirrors how pkg/validator/github.Validator wraps pkg/validator/jwt.Validator.
 type Validator struct {
+	// jwksCheck is the optional JWKS signature check stage. When non-nil
+	// it runs before the inner TokenReview stage. Kept as an independent stage
+	// so a future flag can disable TokenReview and rely on JWKS alone.
+	jwksCheck              validator.TokenValidator
 	inner                  *TokenReviewValidator
 	clusterName            string
 	allowedNamespaces      []string
@@ -136,7 +161,19 @@ func NewValidator(cfg Config) (*Validator, error) {
 		return nil, fmt.Errorf("failed to create token review validator: %w", err)
 	}
 
+	// Build the optional JWKS check stage. The injected jwksValidator wins
+	// (test seam); otherwise it is built from the API server's discovered OIDC
+	// configuration when JWKSCheck is enabled.
+	jwksCheck := cfg.jwksValidator
+	if jwksCheck == nil && cfg.JWKSCheck {
+		jwksCheck, err = newJWKSCheckValidator(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create JWKS check validator: %w", err)
+		}
+	}
+
 	return &Validator{
+		jwksCheck:              jwksCheck,
 		inner:                  inner,
 		clusterName:            cfg.ClusterName,
 		allowedNamespaces:      cfg.AllowedNamespaces,
@@ -149,6 +186,17 @@ func NewValidator(cfg Config) (*Validator, error) {
 // then injects k8s_cluster_name into the claim map and enforces the configured
 // allowlists. Implements validator.TokenValidator.
 func (v *Validator) Validate(ctx context.Context, token string, purpose validator.Purpose) (validator.Claims, error) {
+	// Stage 1: optional JWKS signature check. Rejects a token with a bad
+	// signature, issuer, audience, or expiration before the authoritative
+	// TokenReview round-trip. The JWKS check works from cached keys, so it also
+	// keeps functioning during brief API server downtime.
+	if v.jwksCheck != nil {
+		if _, err := v.jwksCheck.Validate(ctx, token, purpose); err != nil {
+			return nil, fmt.Errorf("JWKS check failed: %w", err)
+		}
+	}
+
+	// Stage 2: authoritative TokenReview.
 	claims, err := v.inner.Validate(ctx, token, purpose)
 	if err != nil {
 		return nil, err

--- a/pkg/validator/k8s/validator.go
+++ b/pkg/validator/k8s/validator.go
@@ -1,7 +1,7 @@
 // Package k8s provides a Kubernetes service-account token validator that
-// authenticates tokens via the Kubernetes TokenReview API and emits SPIRE
-// selectors from the resulting claims. It implements
-// validator.TokenValidator and validator.SelectorGenerator.
+// authenticates tokens via the Kubernetes TokenReview API and/or an in-process
+// JWKS signature check, and emits SPIRE selectors from the resulting claims. It
+// implements validator.TokenValidator and validator.SelectorGenerator.
 package k8s
 
 import (
@@ -66,15 +66,28 @@ type Config struct {
 	// would otherwise be apiHost + caFile + certFile + keyFile.
 	Kubeconfig string `json:"kubeconfig"`
 
-	// JWKSCheck enables a JWKS signature check before TokenReview. When
-	// enabled, a token whose signature, issuer, audience, or expiration fails
-	// verification against the cluster JWKS is rejected without a TokenReview
-	// round-trip to the API server. JWKS check gates on cryptographic validity;
-	// TokenReview additionally validates the token against the cluster's live state.
-	// The signing keys and
-	// issuer are discovered from the API server using the same credentials as
-	// TokenReview and cached. Requires audiences to be set.
+	// JWKSCheck enables a JWKS signature check. When enabled, a token whose
+	// signature, issuer, audience, or expiration fails verification against the
+	// cluster JWKS is rejected. JWKS check gates on cryptographic validity; it is
+	// cheap because keys are fetched periodically and cached, then verification
+	// runs in-process. The signing keys and issuer are discovered from the API
+	// server using the same credentials as TokenReview. Requires audiences to be set.
+	//
+	// JWKSCheck and TokenReview are independent stages. At least one must be
+	// active: JWKSCheck defaults off, TokenReview defaults on (see
+	// DisableTokenReview), so the zero value runs TokenReview alone.
 	JWKSCheck bool `json:"jwksCheck"`
+
+	// DisableTokenReview turns off the authoritative TokenReview stage. By
+	// default TokenReview runs (the zero value keeps it on). TokenReview is the
+	// heavier check because it round-trips to the API server for every token, so
+	// an operator may disable it and rely on the in-process JWKS check alone
+	// (e.g. for throughput or to tolerate brief API server downtime). When
+	// disabled, JWKSCheck must be enabled, because at least one validation stage
+	// must remain active. Note the trade-off: TokenReview is what validates the
+	// token against the cluster's live state, so relying on JWKS alone gives up
+	// that check.
+	DisableTokenReview bool `json:"disableTokenReview"`
 
 	// AuthClient overrides the default-built TokenReview client. Primarily a
 	// test seam — passed through to the inner TokenReviewValidator. Mirrors how
@@ -109,6 +122,12 @@ func (c *Config) ValidateConfig() error {
 		errs = append(errs, errors.New("audiences is required when jwksCheck is enabled"))
 	}
 
+	// At least one validation stage must remain active. TokenReview defaults on,
+	// so the only way to end up with neither is disabling it without jwksCheck.
+	if c.DisableTokenReview && !c.JWKSCheck {
+		errs = append(errs, errors.New("jwksCheck is required when disableTokenReview is set"))
+	}
+
 	// API server connectivity comes from the kubeconfig / in-cluster fallback,
 	// not from individual fields. Only validate that the explicit path exists
 	// if one is set; absence of a path is fine because the resolver will fall
@@ -130,9 +149,10 @@ func (c *Config) NewValidator() (validator.TokenValidatorAndSelectorGenerator, e
 // injection into the claim map and namespace / service-account allowlists.
 // Mirrors how pkg/validator/github.Validator wraps pkg/validator/jwt.Validator.
 type Validator struct {
-	// jwksCheck is the optional JWKS signature check stage. When non-nil
-	// it runs before the inner TokenReview stage. Kept as an independent stage
-	// so a future flag can disable TokenReview and rely on JWKS alone.
+	// jwksCheck and inner are independent validation stages; at least one is
+	// non-nil. jwksCheck is the optional in-process JWKS signature check; inner
+	// is the authoritative TokenReview stage, nil when DisableTokenReview is set.
+	// When both run, JWKS runs first and TokenReview's claims are authoritative.
 	jwksCheck              validator.TokenValidator
 	inner                  *TokenReviewValidator
 	clusterName            string
@@ -152,15 +172,6 @@ func NewValidator(cfg Config) (*Validator, error) {
 		return nil, fmt.Errorf("at least one of allowedNamespaces or allowedServiceAccounts must be specified")
 	}
 
-	inner, err := NewTokenReviewValidator(TokenReviewConfig{
-		Audiences:  cfg.Audiences,
-		Kubeconfig: cfg.Kubeconfig,
-		AuthClient: cfg.AuthClient,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create token review validator: %w", err)
-	}
-
 	// Build the optional JWKS check stage. The injected jwksValidator wins
 	// (test seam); otherwise it is built from the API server's discovered OIDC
 	// configuration when JWKSCheck is enabled.
@@ -169,10 +180,30 @@ func NewValidator(cfg Config) (*Validator, error) {
 		if len(cfg.Audiences) == 0 {
 			return nil, fmt.Errorf("audiences is required when jwksCheck is enabled")
 		}
+		var err error
 		jwksCheck, err = newJWKSCheckValidator(cfg)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create JWKS check validator: %w", err)
 		}
+	}
+
+	// Build the authoritative TokenReview stage unless disabled. When disabled,
+	// jwksCheck must exist so the Validator is not a no-op that accepts every token.
+	var inner *TokenReviewValidator
+	if !cfg.DisableTokenReview {
+		var err error
+		inner, err = NewTokenReviewValidator(TokenReviewConfig{
+			Audiences:  cfg.Audiences,
+			Kubeconfig: cfg.Kubeconfig,
+			AuthClient: cfg.AuthClient,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create token review validator: %w", err)
+		}
+	}
+
+	if inner == nil && jwksCheck == nil {
+		return nil, fmt.Errorf("jwksCheck is required when disableTokenReview is set")
 	}
 
 	return &Validator{
@@ -185,24 +216,32 @@ func NewValidator(cfg Config) (*Validator, error) {
 	}, nil
 }
 
-// Validate delegates token authentication to the inner TokenReviewValidator,
-// then injects k8s_cluster_name into the claim map and enforces the configured
-// allowlists. Implements validator.TokenValidator.
+// Validate runs the configured validation stages, then injects k8s_cluster_name
+// into the claim map and enforces the configured allowlists. Implements
+// validator.TokenValidator.
 func (v *Validator) Validate(ctx context.Context, token string, purpose validator.Purpose) (validator.Claims, error) {
+	var claims validator.Claims
+
 	// Stage 1: optional JWKS signature check. Rejects a token with a bad
-	// signature, issuer, audience, or expiration before the authoritative
-	// TokenReview round-trip. The JWKS check works from cached keys, so it also
-	// keeps functioning during brief API server downtime.
+	// signature, issuer, audience, or expiration. The JWKS check works from
+	// cached keys, so it keeps functioning during brief API server downtime. Its
+	// claims are used downstream only when TokenReview is disabled.
 	if v.jwksCheck != nil {
-		if _, err := v.jwksCheck.Validate(ctx, token, purpose); err != nil {
+		jwksClaims, err := v.jwksCheck.Validate(ctx, token, purpose)
+		if err != nil {
 			return nil, fmt.Errorf("JWKS check failed: %w", err)
 		}
+		claims = jwksClaims
 	}
 
-	// Stage 2: authoritative TokenReview.
-	claims, err := v.inner.Validate(ctx, token, purpose)
-	if err != nil {
-		return nil, err
+	// Stage 2: authoritative TokenReview, unless disabled. When it runs its
+	// claims are authoritative and override the JWKS claims.
+	if v.inner != nil {
+		tokenReviewClaims, err := v.inner.Validate(ctx, token, purpose)
+		if err != nil {
+			return nil, err
+		}
+		claims = tokenReviewClaims
 	}
 
 	// Inject the operator-configured cluster name so templates can reference

--- a/pkg/validator/k8s/validator_test.go
+++ b/pkg/validator/k8s/validator_test.go
@@ -79,6 +79,24 @@ func TestValidateConfig(t *testing.T) {
 				Audiences:         []string{"spire-identity-exchange"},
 			},
 		},
+		{
+			name: "disable_token_review_requires_jwks",
+			cfg: Config{
+				AllowedNamespaces:  []string{"prod"},
+				DisableTokenReview: true,
+			},
+			expectErr: true,
+			errMsg:    "jwksCheck is required when disableTokenReview is set",
+		},
+		{
+			name: "disable_token_review_with_jwks_ok",
+			cfg: Config{
+				AllowedNamespaces:  []string{"prod"},
+				DisableTokenReview: true,
+				JWKSCheck:          true,
+				Audiences:          []string{"spire-identity-exchange"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -268,9 +286,10 @@ func TestValidateWrapsInner(t *testing.T) {
 }
 
 // fakeStageValidator is a test seam standing in for the JWKS check stage.
-// It records whether it ran and returns a configurable error.
+// It records whether it ran and returns a configurable error or claims.
 type fakeStageValidator struct {
 	err    error
+	claims validator.Claims
 	called bool
 }
 
@@ -278,6 +297,9 @@ func (f *fakeStageValidator) Validate(_ context.Context, _ string, _ validator.P
 	f.called = true
 	if f.err != nil {
 		return nil, f.err
+	}
+	if f.claims != nil {
+		return f.claims, nil
 	}
 	return &validator.JWTClaims{}, nil
 }
@@ -323,6 +345,49 @@ func TestJWKSCheckStage(t *testing.T) {
 		assert.Contains(t, err.Error(), "JWKS check failed")
 		assert.Contains(t, err.Error(), "bad signature")
 	})
+}
+
+// TestTokenReviewDisabled verifies that with DisableTokenReview the inner
+// TokenReview stage is not built or run, and the JWKS stage's claims drive the
+// allowlist and cluster-name injection.
+func TestTokenReviewDisabled(t *testing.T) {
+	stage := &fakeStageValidator{
+		claims: &validator.JWTClaims{Raw: map[string]interface{}{
+			"sub": "system:serviceaccount:ns:sa",
+			"kubernetes.io": map[string]interface{}{
+				"namespace":      "ns",
+				"serviceaccount": map[string]interface{}{"name": "sa"},
+			},
+		}},
+	}
+	cfg := Config{
+		ClusterName:        "prod-cluster",
+		AllowedNamespaces:  []string{"ns"},
+		DisableTokenReview: true,
+		// No AuthClient: if the inner stage were built, construction or Validate
+		// would fail, so a passing test proves TokenReview is skipped entirely.
+		jwksValidator: stage,
+	}
+	v, err := NewValidator(cfg)
+	require.NoError(t, err)
+	assert.Nil(t, v.inner, "TokenReview stage should not be built when disabled")
+
+	claims, err := v.Validate(context.Background(), "token", validator.X509Purpose())
+	require.NoError(t, err)
+	assert.True(t, stage.called, "JWKS stage should run")
+	assert.Equal(t, "system:serviceaccount:ns:sa", claims.GetRaw()["sub"])
+	assert.Equal(t, "prod-cluster", claims.GetRaw()["k8s_cluster_name"])
+}
+
+// TestNewValidatorRejectsNoStages confirms a programmatic caller cannot build a
+// Validator with neither stage active, which would accept every token.
+func TestNewValidatorRejectsNoStages(t *testing.T) {
+	_, err := NewValidator(Config{
+		AllowedNamespaces:  []string{"ns"},
+		DisableTokenReview: true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "jwksCheck is required when disableTokenReview is set")
 }
 
 func TestGenerateSelectors(t *testing.T) {

--- a/pkg/validator/k8s/validator_test.go
+++ b/pkg/validator/k8s/validator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"sort"
@@ -60,6 +61,23 @@ func TestValidateConfig(t *testing.T) {
 			},
 			expectErr: true,
 			errMsg:    "kubeconfig not found",
+		},
+		{
+			name: "jwks_check_requires_audiences",
+			cfg: Config{
+				AllowedNamespaces: []string{"prod"},
+				JWKSCheck:         true,
+			},
+			expectErr: true,
+			errMsg:    "audiences is required when jwksCheck is enabled",
+		},
+		{
+			name: "jwks_check_with_audiences_ok",
+			cfg: Config{
+				AllowedNamespaces: []string{"prod"},
+				JWKSCheck:         true,
+				Audiences:         []string{"spire-identity-exchange"},
+			},
 		},
 	}
 
@@ -246,6 +264,64 @@ func TestValidateWrapsInner(t *testing.T) {
 		_, err = denyV.Validate(context.Background(), mkProjectedToken("system:serviceaccount:ns:sa", "ns", "sa"), validator.X509Purpose())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), `namespace "ns" is not in the allowed list`)
+	})
+}
+
+// fakeStageValidator is a test seam standing in for the JWKS check stage.
+// It records whether it ran and returns a configurable error.
+type fakeStageValidator struct {
+	err    error
+	called bool
+}
+
+func (f *fakeStageValidator) Validate(_ context.Context, _ string, _ validator.Purpose) (validator.Claims, error) {
+	f.called = true
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &validator.JWTClaims{}, nil
+}
+
+// TestJWKSCheckStage verifies the two-stage composition: the JWKS check
+// runs before TokenReview, and a JWKS check failure short-circuits before the
+// authoritative TokenReview call.
+func TestJWKSCheckStage(t *testing.T) {
+	mkValidator := func(jwksErr error) (*Validator, *fakeStageValidator) {
+		stage := &fakeStageValidator{err: jwksErr}
+		cfg := Config{
+			AllowedNamespaces: []string{"ns"},
+			// TokenReview is configured to succeed, so any failure must come from
+			// the JWKS check stage.
+			AuthClient: &mockAuthV1Client{
+				tokenValid:     true,
+				returnUsername: "system:serviceaccount:ns:sa",
+			},
+			jwksValidator: stage,
+		}
+		v, err := NewValidator(cfg)
+		require.NoError(t, err)
+		return v, stage
+	}
+
+	token := mkProjectedToken("system:serviceaccount:ns:sa", "ns", "sa")
+
+	t.Run("JWKS check passes then TokenReview runs", func(t *testing.T) {
+		v, stage := mkValidator(nil)
+		claims, err := v.Validate(context.Background(), token, validator.X509Purpose())
+		require.NoError(t, err)
+		assert.True(t, stage.called, "JWKS check stage should run")
+		assert.Equal(t, "system:serviceaccount:ns:sa", claims.GetRaw()["sub"])
+	})
+
+	t.Run("JWKS check failure short-circuits before TokenReview", func(t *testing.T) {
+		v, stage := mkValidator(errors.New("bad signature"))
+		_, err := v.Validate(context.Background(), token, validator.X509Purpose())
+		require.Error(t, err)
+		assert.True(t, stage.called, "JWKS check stage should run")
+		// TokenReview would have authenticated successfully, so an error here
+		// proves the JWKS check failure stopped the flow.
+		assert.Contains(t, err.Error(), "JWKS check failed")
+		assert.Contains(t, err.Error(), "bad signature")
 	})
 }
 

--- a/pkg/validator/k8s/validator_test.go
+++ b/pkg/validator/k8s/validator_test.go
@@ -27,15 +27,33 @@ func TestValidateConfig(t *testing.T) {
 		errMsg    string
 	}{
 		{
+			// Default (nothing set) runs JWKS, which needs audiences.
+			name: "default_requires_audiences",
+			cfg: Config{
+				AllowedNamespaces: []string{"prod"},
+			},
+			expectErr: true,
+			errMsg:    "audiences is required when jwksCheck is enabled",
+		},
+		{
+			name: "default_with_audiences_ok",
+			cfg: Config{
+				AllowedNamespaces: []string{"prod"},
+				Audiences:         []string{"spire-identity-exchange"},
+			},
+		},
+		{
 			name: "valid_config_namespaces",
 			cfg: Config{
 				AllowedNamespaces: []string{"prod"},
+				JWKSCheck:         ptr(false),
 			},
 		},
 		{
 			name: "valid_config_service_accounts",
 			cfg: Config{
 				AllowedServiceAccounts: []string{"prod/web"},
+				JWKSCheck:              ptr(false),
 			},
 		},
 		{
@@ -43,12 +61,14 @@ func TestValidateConfig(t *testing.T) {
 			cfg: Config{
 				AllowedNamespaces: []string{"prod"},
 				Kubeconfig:        kubeconfig,
+				JWKSCheck:         ptr(false),
 			},
 		},
 		{
 			name: "missing_allowlists",
 			cfg: Config{
 				Kubeconfig: kubeconfig,
+				JWKSCheck:  ptr(false),
 			},
 			expectErr: true,
 			errMsg:    "at least one of allowedNamespaces or allowedServiceAccounts",
@@ -58,6 +78,7 @@ func TestValidateConfig(t *testing.T) {
 			cfg: Config{
 				AllowedNamespaces: []string{"prod"},
 				Kubeconfig:        filepath.Join(dir, "missing-kubeconfig"),
+				JWKSCheck:         ptr(false),
 			},
 			expectErr: true,
 			errMsg:    "kubeconfig not found",
@@ -66,7 +87,7 @@ func TestValidateConfig(t *testing.T) {
 			name: "jwks_check_requires_audiences",
 			cfg: Config{
 				AllowedNamespaces: []string{"prod"},
-				JWKSCheck:         true,
+				JWKSCheck:         ptr(true),
 			},
 			expectErr: true,
 			errMsg:    "audiences is required when jwksCheck is enabled",
@@ -75,26 +96,27 @@ func TestValidateConfig(t *testing.T) {
 			name: "jwks_check_with_audiences_ok",
 			cfg: Config{
 				AllowedNamespaces: []string{"prod"},
-				JWKSCheck:         true,
+				JWKSCheck:         ptr(true),
 				Audiences:         []string{"spire-identity-exchange"},
 			},
 		},
 		{
-			name: "disable_token_review_requires_jwks",
+			name: "both_stages_disabled_rejected",
 			cfg: Config{
-				AllowedNamespaces:  []string{"prod"},
-				DisableTokenReview: true,
+				AllowedNamespaces: []string{"prod"},
+				JWKSCheck:         ptr(false),
+				TokenReview:       ptr(false),
 			},
 			expectErr: true,
-			errMsg:    "jwksCheck is required when disableTokenReview is set",
+			errMsg:    "at least one of jwksCheck or tokenReview must be enabled",
 		},
 		{
-			name: "disable_token_review_with_jwks_ok",
+			name: "token_review_disabled_with_jwks_ok",
 			cfg: Config{
-				AllowedNamespaces:  []string{"prod"},
-				DisableTokenReview: true,
-				JWKSCheck:          true,
-				Audiences:          []string{"spire-identity-exchange"},
+				AllowedNamespaces: []string{"prod"},
+				TokenReview:       ptr(false),
+				JWKSCheck:         ptr(true),
+				Audiences:         []string{"spire-identity-exchange"},
 			},
 		},
 	}
@@ -124,12 +146,15 @@ func TestNewValidator(t *testing.T) {
 			cfg: Config{
 				AllowedNamespaces: []string{"prod"},
 				AuthClient:        &mockAuthV1Client{tokenValid: true},
+				// JWKS off so construction does not attempt live OIDC discovery.
+				JWKSCheck: ptr(false),
 			},
 		},
 		{
 			name: "missing_allowlists",
 			cfg: Config{
 				AuthClient: &mockAuthV1Client{tokenValid: true},
+				JWKSCheck:  ptr(false),
 			},
 			expectErr: true,
 			errMsg:    "at least one of allowedNamespaces or allowedServiceAccounts",
@@ -245,6 +270,8 @@ func TestValidateWrapsInner(t *testing.T) {
 			tokenValid:     true,
 			returnUsername: "system:serviceaccount:ns:sa",
 		},
+		// This suite exercises the TokenReview path only.
+		JWKSCheck: ptr(false),
 	}
 
 	v, err := NewValidator(cfg)
@@ -275,6 +302,7 @@ func TestValidateWrapsInner(t *testing.T) {
 				tokenValid:     true,
 				returnUsername: "system:serviceaccount:ns:sa",
 			},
+			JWKSCheck: ptr(false),
 		}
 		denyV, err := NewValidator(denyCfg)
 		require.NoError(t, err)
@@ -361,9 +389,9 @@ func TestTokenReviewDisabled(t *testing.T) {
 		}},
 	}
 	cfg := Config{
-		ClusterName:        "prod-cluster",
-		AllowedNamespaces:  []string{"ns"},
-		DisableTokenReview: true,
+		ClusterName:       "prod-cluster",
+		AllowedNamespaces: []string{"ns"},
+		TokenReview:       ptr(false),
 		// No AuthClient: if the inner stage were built, construction or Validate
 		// would fail, so a passing test proves TokenReview is skipped entirely.
 		jwksValidator: stage,
@@ -383,12 +411,16 @@ func TestTokenReviewDisabled(t *testing.T) {
 // Validator with neither stage active, which would accept every token.
 func TestNewValidatorRejectsNoStages(t *testing.T) {
 	_, err := NewValidator(Config{
-		AllowedNamespaces:  []string{"ns"},
-		DisableTokenReview: true,
+		AllowedNamespaces: []string{"ns"},
+		JWKSCheck:         ptr(false),
+		TokenReview:       ptr(false),
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "jwksCheck is required when disableTokenReview is set")
+	assert.Contains(t, err.Error(), "at least one of jwksCheck or tokenReview must be enabled")
 }
+
+// ptr returns a pointer to b, for setting the optional *bool config flags.
+func ptr(b bool) *bool { return &b }
 
 func TestGenerateSelectors(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
- Add `jwksCheck` config option to the k8s SA token validator
- When enabled, verifies token signature/issuer/audience/expiry against the cluster JWKS before TokenReview
- Keys and issuer are auto-discovered from the API server using the same credentials as TokenReview
- JWKS check failure is definitive (no fallback); TokenReview still runs on success
- Defaults to off — existing behavior unchanged