### PR TITLE
Add server attestor for security

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ all: build test
 # To add a new command, simply add a new line here.
 APPS := \
 	spire-credentialcomposer-identity-exchange:cmd/spire-credentialcomposer-identity-exchange:linux/amd64,linux/arm64 \
+	spire-server-attestor-spiffe-workload-api:cmd/spire-server-attestor-spiffe-workload-api:linux/amd64,linux/arm64 \
 	spire-identity-exchange-server:cmd/spire-identity-exchange-server:linux/amd64,linux/arm64
 
 # --- Build Logic ---

--- a/cmd/spire-server-attestor-spiffe-workload-api/main.go
+++ b/cmd/spire-server-attestor-spiffe-workload-api/main.go
@@ -51,8 +51,8 @@ func trustBundleHandler(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "Usage:", os.Args[0], "<socket_path_to_listen_on>")
-		return
+		fmt.Fprintf(os.Stderr, "Usage: %s <socket_path_to_listen_on>\n", os.Args[0])
+		os.Exit(2)
 	}
 	socket = os.Args[1]
 

--- a/cmd/spire-server-attestor-spiffe-workload-api/main.go
+++ b/cmd/spire-server-attestor-spiffe-workload-api/main.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+)
+
+var (
+	socket       string
+	bundleSource *workloadapi.BundleSource
+	targetDomain spiffeid.TrustDomain
+)
+
+func trustBundleHandler(w http.ResponseWriter, r *http.Request) {
+	bundle, err := bundleSource.GetBundleForTrustDomain(targetDomain)
+	if err != nil {
+		fmt.Printf("Failed to locate bundle for trust domain %s: %v\n", targetDomain.String(), err)
+		http.Error(w, "Trust bundle not found for configured domain", http.StatusNotFound)
+		return
+	}
+
+	certs := bundle.X509Authorities()
+	if len(certs) == 0 {
+		fmt.Printf("No X509 authorities found in the bundle for %s\n", targetDomain.String())
+		http.Error(w, "No certificates in trust bundle", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/x-pem-file")
+	w.WriteHeader(http.StatusOK)
+
+	for _, cert := range certs {
+		pemBlock := &pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: cert.Raw,
+		}
+
+		if err := pem.Encode(w, pemBlock); err != nil {
+			fmt.Printf("Failed to write PEM block to response: %v\n", err)
+			return
+		}
+	}
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "Usage:", os.Args[0], "<socket_path_to_listen_on>")
+		return
+	}
+	socket = os.Args[1]
+
+	envTD := os.Getenv("SPIFFE_TRUST_DOMAIN")
+	if envTD == "" {
+		fmt.Fprintln(os.Stderr, "Error: SPIFFE_TRUST_DOMAIN environment variable is missing or empty")
+		os.Exit(1)
+	}
+
+	var err error
+	targetDomain, err = spiffeid.TrustDomainFromString(envTD)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Failed to parse trust domain from SPIFFE_TRUST_DOMAIN: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Configured to serve trust bundle for: %s\n", targetDomain.String())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fmt.Println("Connecting to SPIFFE Workload API and initializing background stream...")
+
+	bundleSource, err = workloadapi.NewBundleSource(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to initialize SPIFFE bundle source: %v\n", err)
+		os.Exit(1)
+	}
+	defer bundleSource.Close()
+
+	fmt.Printf("Starting HTTP server on Unix Socket: %s\n", socket)
+
+	if err := os.Remove(socket); err != nil && !os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "Failed to clean socket path: %v\n", err)
+		os.Exit(1)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/trustbundle", trustBundleHandler)
+
+	server := http.Server{
+		Handler: mux,
+	}
+
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error listening on unix socket: %v\n", err)
+		os.Exit(1)
+	}
+	defer listener.Close()
+
+	_ = os.Chmod(socket, 0777)
+
+	if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+		fmt.Fprintf(os.Stderr, "Server encountered error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/systemd/spire-server-attestor-spiffe-workload-api@.service
+++ b/systemd/spire-server-attestor-spiffe-workload-api@.service
@@ -6,14 +6,13 @@ Wants=network-online.target local-fs.target time-sync.target remote-fs-pre.targe
 StartLimitIntervalSec=0
 
 [Service]
-WorkingDirectory=/var/lib/spire
-RuntimeDirectory=spire
+WorkingDirectory=/
+RuntimeDirectory=spire/server-attestor-spiffe-workload-api/%i
 RuntimeDirectoryPreserve=true
 ConfigurationDirectory=spire
 EnvironmentFile=-/etc/spiffe/default-trust-domain.env
 Environment=SYSTEMD_INSTANCE=%i
 Environment=SPIFFE_ENDPOINT_SOCKET=unix:///var/run/spire/agent/sockets/%i/public/api.sock
-ExecStartPre=/bin/bash -c "mkdir -p /var/run/spire/server-attestor-spiffe-workload-api/%i"
 ExecStart=/usr/libexec/spire/spire-server-attestor-spiffe-workload-api /var/run/spire/server-attestor-spiffe-workload-api/%i/socket
 # https://gist.github.com/ageis/f5595e59b1cddb1513d1b425a323db04
 LockPersonality=true

--- a/systemd/spire-server-attestor-spiffe-workload-api@.service
+++ b/systemd/spire-server-attestor-spiffe-workload-api@.service
@@ -1,0 +1,42 @@
+[Unit]
+Description=SPIRE Server Attestor SPIFFE workload api %i
+After=network-online.target local-fs.target time-sync.target
+Before=remote-fs-pre.target
+Wants=network-online.target local-fs.target time-sync.target remote-fs-pre.target
+StartLimitIntervalSec=0
+
+[Service]
+WorkingDirectory=/var/lib/spire
+RuntimeDirectory=spire/
+RuntimeDirectoryPreserve=true
+ConfigurationDirectory=spire
+EnvironmentFile=-/etc/spiffe/default-trust-domain.env
+Environment=SYSTEMD_INSTANCE=%i
+Environment=SPIFFE_ENDPOINT_SOCKET=unix:///var/run/spire/agent/sockets/main/public/api.sock
+ExecStartPre=/bin/bash -c "mkdir -p /var/run/spire/server-attestor-spiffe-workload-api/%i"
+ExecStart=/usr/libexec/spire/spire-server-attestor-spiffe-workload-api /var/run/spire/server-attestor-spiffe-workload-api/main/socket
+# https://gist.github.com/ageis/f5595e59b1cddb1513d1b425a323db04
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+PrivateDevices=false
+# Needed by plugins
+PrivateTmp=false
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectSystem=strict
+ReadOnlyPaths=/
+Restart=always
+RestartSec=5s
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+RestrictNamespaces=true
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+TasksMax=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/spire-server-attestor-spiffe-workload-api@.service
+++ b/systemd/spire-server-attestor-spiffe-workload-api@.service
@@ -7,14 +7,14 @@ StartLimitIntervalSec=0
 
 [Service]
 WorkingDirectory=/var/lib/spire
-RuntimeDirectory=spire/
+RuntimeDirectory=spire
 RuntimeDirectoryPreserve=true
 ConfigurationDirectory=spire
 EnvironmentFile=-/etc/spiffe/default-trust-domain.env
 Environment=SYSTEMD_INSTANCE=%i
-Environment=SPIFFE_ENDPOINT_SOCKET=unix:///var/run/spire/agent/sockets/main/public/api.sock
+Environment=SPIFFE_ENDPOINT_SOCKET=unix:///var/run/spire/agent/sockets/%i/public/api.sock
 ExecStartPre=/bin/bash -c "mkdir -p /var/run/spire/server-attestor-spiffe-workload-api/%i"
-ExecStart=/usr/libexec/spire/spire-server-attestor-spiffe-workload-api /var/run/spire/server-attestor-spiffe-workload-api/main/socket
+ExecStart=/usr/libexec/spire/spire-server-attestor-spiffe-workload-api /var/run/spire/server-attestor-spiffe-workload-api/%i/socket
 # https://gist.github.com/ageis/f5595e59b1cddb1513d1b425a323db04
 LockPersonality=true
 MemoryDenyWriteExecute=true

--- a/tests/integration/common/common.sh
+++ b/tests/integration/common/common.sh
@@ -107,6 +107,15 @@ deploy_credential_composer() {
   /usr/libexec/spire/plugins/credentialcomposer-identity-exchange || true
 }
 
+deploy_server_attestor() {
+  go build -o spire-server-attestor-spiffe-workload-api cmd/spire-server-attestor-spiffe-workload-api/main.go
+  sudo mkdir -p /usr/libexec/spire/plugins
+  sudo cp -a spire-server-attestor-spiffe-workload-api /usr/libexec/spire/spire-server-attestor-spiffe-workload-api
+  sudo cp -a systemd/spire-server-attestor-spiffe-workload-api@.service /usr/lib/systemd/system
+  sudo systemctl daemon-reload
+  sudo systemctl start spire-server-attestor-spiffe-workload-api@main
+}
+
 setup_base_spire() {
   local SCRIPTPATH="$1"
   local COMMONPATH="$2"

--- a/tests/integration/common/common.sh
+++ b/tests/integration/common/common.sh
@@ -111,7 +111,7 @@ deploy_server_attestor() {
   go build -o spire-server-attestor-spiffe-workload-api cmd/spire-server-attestor-spiffe-workload-api/main.go
   sudo mkdir -p /usr/libexec/spire/plugins
   sudo cp -a spire-server-attestor-spiffe-workload-api /usr/libexec/spire/spire-server-attestor-spiffe-workload-api
-  sudo cp -a systemd/spire-server-attestor-spiffe-workload-api@.service /usr/lib/systemd/system
+  sudo cp -a systemd/spire-server-attestor-spiffe-workload-api@.service /etc/systemd/system
   sudo systemctl daemon-reload
   sudo systemctl start spire-server-attestor-spiffe-workload-api@main
 }

--- a/tests/integration/common/manifests/node1-spire-server-attestor-spiffe-workload-api.yaml
+++ b/tests/integration/common/manifests/node1-spire-server-attestor-spiffe-workload-api.yaml
@@ -1,0 +1,9 @@
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterStaticEntry
+metadata:
+  name: node1-spire-server-attestor-spiffe-workload-api
+spec:
+  parentID: spiffe://${SPIFFE_TRUST_DOMAIN}/agent/node1
+  spiffeID: spiffe://${SPIFFE_TRUST_DOMAIN}/spire-server-attestor-spiffe-workload-api
+  selectors:
+  - systemd:id:spire-server-attestor-spiffe-workload-api@main.service

--- a/tests/integration/common/six-agent.conf
+++ b/tests/integration/common/six-agent.conf
@@ -4,9 +4,11 @@ agent {
     server_address = "localhost"
     server_port = ${SPIRE_SERVER_PORT}
 
-    # Insecure bootstrap is NOT appropriate for production use but is ok for
-    # simple testing/evaluation purposes.
-    insecure_bootstrap = true
+    trust_bundle_url = "http://localhost/trustbundle"
+    trust_bundle_unix_socket = "/var/run/spire/server-attestor-spiffe-workload-api/sock"
+
+    rebootstrap_mode = "always"
+    rebootstrap_delay = "5m"
 
     admin_socket_path = "${SPIRE_AGENT_ADMIN_ADDRESS}"
     authorized_delegates = ["spiffe://${SPIFFE_TRUST_DOMAIN}/service/spire-identity-exchange"]

--- a/tests/integration/common/six-agent.conf
+++ b/tests/integration/common/six-agent.conf
@@ -5,8 +5,7 @@ agent {
     server_port = ${SPIRE_SERVER_PORT}
 
     trust_bundle_url = "http://localhost/trustbundle"
-    trust_bundle_unix_socket = "/var/run/spire/server-attestor-spiffe-workload-api/sock"
-
+    trust_bundle_unix_socket = "/var/run/spire/server-attestor-spiffe-workload-api/main/socket"
     rebootstrap_mode = "always"
     rebootstrap_delay = "5m"
 

--- a/tests/integration/github/run-tests.sh
+++ b/tests/integration/github/run-tests.sh
@@ -20,6 +20,8 @@ teardown() {
   echo ---------------------------
   echo "::group::Status Output"
   sudo journalctl -u spire-identity-exchange@main.service || true
+  sudo journalctl -u spire-server-attestor-spiffe-workload-api@main.service || true
+  sudo systemctl status spire-server-attestor-spiffe-workload-api@main.service || true
   sudo spire-server agent show -spiffeID spiffe://example.org/spire/agent/x509pop/spire-identity-exchange/node1 || true
   sudo systemctl status spire-identity-exchange@main.service -n 50 2>&1 || true
   sudo systemctl status spire-server@main -n 50 2>&1 || true

--- a/tests/integration/github/run-tests.sh
+++ b/tests/integration/github/run-tests.sh
@@ -32,6 +32,7 @@ teardown() {
 trap 'EC=$? && trap - SIGTERM && teardown $EC' SIGINT SIGTERM EXIT
 
 deploy_credential_composer
+deploy_server_attestor
 
 # Setup github mock service. Consider moving this out to a systemd service
 go build -o mock-github-oidc ${SCRIPTPATH}/../../../examples/mock-github-oidc/main.go

--- a/tests/integration/k8s_psat/run-tests.sh
+++ b/tests/integration/k8s_psat/run-tests.sh
@@ -38,6 +38,7 @@ teardown() {
 trap 'EC=$? && trap - SIGTERM && teardown $EC' SIGINT SIGTERM EXIT
 
 deploy_credential_composer
+deploy_server_attestor
 
 sudo mkdir -p /etc/spire/server/main/manifests
 sudo cp "${SCRIPTPATH}/manifests"/* /etc/spire/server/main/manifests/

--- a/tests/integration/spiffe/run-tests.sh
+++ b/tests/integration/spiffe/run-tests.sh
@@ -34,6 +34,7 @@ teardown() {
 trap 'EC=$? && trap - SIGTERM && teardown $EC' SIGINT SIGTERM EXIT
 
 deploy_credential_composer
+deploy_server_attestor
 
 sudo mkdir -p /etc/spire/server/main/manifests
 sudo cp "${SCRIPTPATH}/manifests"/* /etc/spire/server/main/manifests/


### PR DESCRIPTION
This allows the spire-identity-exchange agent, to use the underlying spire-agent as its source of truth for its trust bundle.