### PR TITLE
Add JWT-SVID REST endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,16 @@ curl -k -X POST https://localhost:8444/api/v1/svid/github-actions/x509 \
   -H "Content-Type: application/json"
 ```
 
+**6. Mint a JWT-SVID via the REST API:**
+```bash
+export GITHUB_TOKEN="<token from mock server output>"
+
+curl -k -X POST https://localhost:8444/api/v1/svid/github-actions/jwt \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"audiences": ["my-workload-audience"]}'
+```
+
 ### Inspecting the service
 
 ```bash

--- a/internal/service/runner.go
+++ b/internal/service/runner.go
@@ -9,6 +9,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -287,6 +288,7 @@ func runSpireIdentityExchangeServer(
 		mux.HandleFunc("GET /api/v1/trustbundle/x509", handleTrustBundleX509(cache, logger))
 		purposeResolver := validator.NewPurposeResolver(validator.PurposeMode(cfg.PurposeMode))
 		mux.HandleFunc("POST /api/v1/svid/{stack}/x509", handleGetX509SVID(cfg, cache, delegatedClient, purposeResolver, logger))
+		mux.HandleFunc("POST /api/v1/svid/{stack}/jwt", handleGetJWTSVID(cfg, delegatedClient, purposeResolver, logger))
 
 		httpServer = &http.Server{
 			Addr:              fmt.Sprintf(":%d", cfg.Server.RestPort),
@@ -527,6 +529,120 @@ func handleGetX509SVID(cfg *config.SpireIdentityExchangeConfig, cache *trustBund
 		default:
 			logger.Error("response encode failed")
 			http.Error(w, "Invalid format", http.StatusBadRequest)
+		}
+	}
+}
+
+// jwtSVIDRequest is the JSON body expected by POST /api/v1/svid/{stack}/jwt.
+type jwtSVIDRequest struct {
+	Audiences []string `json:"audiences"`
+}
+
+// jwtSVIDResponse is the JSON body returned by POST /api/v1/svid/{stack}/jwt.
+type jwtSVIDResponse struct {
+	SpiffeID  string `json:"spiffeId"`
+	Token     string `json:"token"`
+	ExpiresAt int64  `json:"expiresAt"` // Unix seconds
+}
+
+// handleGetJWTSVID validates the bearer token, derives selectors via the
+// stack's SelectorGenerator, fetches a JWT-SVID via the delegated client for
+// the requested audiences, and returns it as JSON.
+//
+// Error mapping mirrors handleGetX509SVID:
+//   - missing/malformed Authorization header  → 401
+//   - unknown {stack} path-param              → 400
+//   - malformed body / empty audiences        → 400
+//   - token rejected by validator              → 401
+//   - validator returned no selectors          → 400
+//   - delegated client found no matching entry → 404
+//   - delegated client unavailable / denied    → 503
+//   - any other error                          → 500
+func handleGetJWTSVID(cfg *config.SpireIdentityExchangeConfig, dc *delegated.Client, pr *validator.PurposeResolver, logger *zap.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		token, err := extractBearerToken(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusUnauthorized)
+			return
+		}
+
+		stack := r.PathValue("stack")
+		if stack == "" {
+			http.Error(w, "Stack parameter is missing", http.StatusBadRequest)
+			return
+		}
+		v, exists := cfg.Auth.LoadedStacks[stack]
+		if !exists {
+			http.Error(w, fmt.Sprintf("Unknown stack: %q", stack), http.StatusBadRequest)
+			return
+		}
+
+		var req jwtSVIDRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			http.Error(w, "Malformed request body", http.StatusBadRequest)
+			return
+		}
+		if len(req.Audiences) == 0 {
+			http.Error(w, "audiences must be non-empty", http.StatusBadRequest)
+			return
+		}
+
+		claims, err := v.Validate(r.Context(), token, pr.JWT(req.Audiences))
+		if err != nil {
+			logger.Info("token validation failed", zap.String("stack", stack), zap.Error(err))
+			http.Error(w, "Invalid token", http.StatusUnauthorized)
+			return
+		}
+
+		selectors := v.GenerateSelectors(claims)
+		if len(selectors) == 0 {
+			http.Error(w, "No selectors derivable from token claims", http.StatusBadRequest)
+			return
+		}
+
+		svid, err := dc.FetchJWTSVID(r.Context(), selectors, req.Audiences)
+		switch {
+		case errors.Is(err, delegated.ErrNoMatchingEntry):
+			logger.Info("no entry matched selectors",
+				zap.String("stack", stack),
+				zap.Int("selector_count", len(selectors)),
+				zap.Any("selectors", debugSelectors(selectors)))
+			http.Error(w, "No registration entry matches the validated identity", http.StatusNotFound)
+			return
+		case errors.Is(err, delegated.ErrPermissionDenied):
+			logger.Error("delegated API rejected this exchange — check authorized_delegates", zap.Error(err))
+			http.Error(w, "Delegated issuance unavailable", http.StatusServiceUnavailable)
+			return
+		case errors.Is(err, delegated.ErrUnavailable):
+			logger.Error("delegated API unavailable", zap.Error(err))
+			http.Error(w, "Delegated issuance unavailable", http.StatusServiceUnavailable)
+			return
+		case errors.Is(err, delegated.ErrInvalidArgument):
+			// SIE built the selectors from claims it just validated, so a
+			// rejection here is a server-side bug, not a client request error.
+			logger.Error("delegated API rejected selectors as invalid",
+				zap.String("stack", stack),
+				zap.Any("selectors", debugSelectors(selectors)),
+				zap.Error(err))
+			http.Error(w, "Issuance failed", http.StatusInternalServerError)
+			return
+		case err != nil:
+			logger.Error("delegated svid fetch failed", zap.Error(err))
+			http.Error(w, "Issuance failed", http.StatusInternalServerError)
+			return
+		}
+
+		resp := jwtSVIDResponse{
+			SpiffeID:  svid.SpiffeID,
+			Token:     svid.Token,
+			ExpiresAt: svid.ExpiresAt.Unix(),
+		}
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Pragma", "no-cache")
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(&resp); err != nil {
+			logger.Error("response encode failed", zap.Error(err))
+			http.Error(w, "encoding failed", http.StatusInternalServerError)
 		}
 	}
 }

--- a/tests/integration/github/default.conf
+++ b/tests/integration/github/default.conf
@@ -21,7 +21,7 @@
     "plugins": [{
       "plugin": "github",
       "config": {
-        "allowedRepositories": ["spiffe/spire-identity-exchange", "${GITHUB_REPOSITORY}"],
+        "allowedRepositories": ["spiffe/spire-identity-exchange"],
         "audiences": ["spire-identity-exchange"]
       }
     },{

--- a/tests/integration/github/default.conf
+++ b/tests/integration/github/default.conf
@@ -1,7 +1,7 @@
 {
   "name": "spire-identity-exchange",
   "logLevel": "info",
-  "purposeMode": "shared",
+  "purposeMode": "purpose",
   "server": {
     "grpcPort": 8443,
     "metricsPort": 4950,
@@ -21,7 +21,7 @@
     "plugins": [{
       "plugin": "github",
       "config": {
-        "allowedRepositories": ["spiffe/spire-identity-exchange"],
+        "allowedRepositories": ["spiffe/spire-identity-exchange", "${GITHUB_REPOSITORY}"],
         "audiences": ["spire-identity-exchange"]
       }
     },{

--- a/tests/integration/github/run-tests.sh
+++ b/tests/integration/github/run-tests.sh
@@ -63,6 +63,13 @@ sudo cp "${SCRIPTPATH}/manifests"/* /etc/spire/server/main/manifests/
 # Common spire setup bits
 setup_base_spire "${SCRIPTPATH}" "${SCRIPTPATH}/../common"
 
+# allowedRepositories in default.conf expands ${GITHUB_REPOSITORY} so this test
+# passes on forks too, not just spiffe/spire-identity-exchange. The service reads
+# it via EnvironmentFile=-/etc/spire/identity-exchange/%i/env, so it must be
+# written before the service (re)starts.
+sudo mkdir -p /etc/spire/identity-exchange
+sudo /bin/bash -c "echo GITHUB_REPOSITORY=${GITHUB_REPOSITORY} > /etc/spire/identity-exchange/main/env"
+
 setup_identity_exchange "${SCRIPTPATH}" "${SCRIPTPATH}/../common"
 
 # Tests
@@ -98,4 +105,10 @@ if [ -n "$GITHUB_TOKEN" ]; then
 fi
 
 curl -f -H "Authorization: Bearer ${MOCKHUB_TOKEN}" -X POST https://localhost:8444/api/v1/svid/mockhub/x509 --cacert /etc/spire/identity-exchange/main/certs/server.pem -sS
+
+if [ -n "$GITHUB_TOKEN" ]; then
+	curl -f -H "Authorization: Bearer ${GITHUB_TOKEN}" -H "Content-Type: application/json" -d '{"audiences": ["foo"]}' -X POST https://localhost:8444/api/v1/svid/github/jwt --cacert /etc/spire/identity-exchange/main/certs/server.pem -sS
+fi
+
+curl -f -H "Authorization: Bearer ${MOCKHUB_TOKEN}" -H "Content-Type: application/json" -d '{"audiences": ["bar"]}' -X POST https://localhost:8444/api/v1/svid/mockhub/jwt --cacert /etc/spire/identity-exchange/main/certs/server.pem -sS
 

--- a/tests/integration/github/run-tests.sh
+++ b/tests/integration/github/run-tests.sh
@@ -63,13 +63,6 @@ sudo cp "${SCRIPTPATH}/manifests"/* /etc/spire/server/main/manifests/
 # Common spire setup bits
 setup_base_spire "${SCRIPTPATH}" "${SCRIPTPATH}/../common"
 
-# allowedRepositories in default.conf expands ${GITHUB_REPOSITORY} so this test
-# passes on forks too, not just spiffe/spire-identity-exchange. The service reads
-# it via EnvironmentFile=-/etc/spire/identity-exchange/%i/env, so it must be
-# written before the service (re)starts.
-sudo mkdir -p /etc/spire/identity-exchange
-sudo /bin/bash -c "echo GITHUB_REPOSITORY=${GITHUB_REPOSITORY} > /etc/spire/identity-exchange/main/env"
-
 setup_identity_exchange "${SCRIPTPATH}" "${SCRIPTPATH}/../common"
 
 # Tests


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/svid/{stack}/jwt`, mirroring the existing X.509
  REST endpoint, to mint JWT-SVIDs over REST via the same plugin auth
  stacks
- Document the new endpoint in README
- Extend the github integration test to exercise it, and switch its
  purposeMode to `purpose` so reusing a token across SVID types
  doesn't collide once replay-cache checking is wired to the plugin
  path